### PR TITLE
Add Midea AC protocol decoder/encoder with multi-frame support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.idea/

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ The `toggle` parameter can be 0 or 1 and is optional. It helps to distinguish be
 
 - **ac**: Some air conditioners use this protocol (at least Gorenie and MDV). Usually 16-bit command contains 4-bit mode, 4-bit fan speed, 4-bit temperature and some other bits. Requires `addr` and `cmd`.
 
+- **midea**: Midea-family AC protocol (48-bit, packet repeated as-is). Used by Midea-OEM rebranders such as Pioneer System, Comfee, Kaysun, Trotec, Lennox, EAS Electric, MDV, and many no-name Chinese splits. The frame contains a fixed `0xB2` vendor marker, two payload bytes `a` and `b`, and inverse copies of all three. Requires `a` (mode/fan/power byte) and `b` (temperature/swing byte) — the exact field layout within these bytes is OEM-specific, so the integration exposes them as raw bytes and leaves the per-OEM mapping to the user. Use `remote.learn_command` to capture the bytes for each combination of (mode, temp, fan) you want to control. The `auto-decode` step picks `midea` over `ac` whenever the vendor byte equals `0xB2`. Sample: `midea:a=0x7B,b=0xE0` (a real "Power off" command from EAS Electric EADVA25NT2).
+
 
 ## Sub-GHz Code Formatting
 

--- a/README.md
+++ b/README.md
@@ -258,9 +258,9 @@ The `toggle` parameter can be 0 or 1 and is optional. It helps to distinguish be
 
 - **ac**: Some air conditioners use this protocol (at least Gorenie and MDV). Usually 16-bit command contains 4-bit mode, 4-bit fan speed, 4-bit temperature and some other bits. Requires `addr` and `cmd`.
 
-- **midea**: Midea-family AC protocol (48-bit). Used by Midea-OEM rebranders such as Pioneer System, Comfee, Kaysun, Trotec, Lennox, EAS Electric, MDV, and many no-name Chinese splits. The frame contains a fixed `0xB2` vendor marker, two payload bytes `a` (mode/fan/power) and `b` (temperature/mode), plus inverse copies of all three. The `auto-decode` step picks `midea` over `ac` whenever the vendor byte equals `0xB2`.
+- **midea**: Midea-family AC protocol (48-bit). Used by Midea-OEM rebranders such as Pioneer System, Comfee, Kaysun, Trotec, Lennox, EAS Electric, MDV, and many no-name Chinese splits. State frames use vendor marker `0xB2` and contain two payload bytes `a` (mode/fan/power) and `b` (temperature/mode), plus inverse copies of all three; some toggle/special button commands use vendor marker `0xB5` instead. The `auto-decode` step picks `midea` over `ac` whenever the vendor byte equals `0xB2` or `0xB5`.
 
-  **Two parameter forms** are supported (mutually exclusive):
+  **Three parameter forms** are supported (mutually exclusive):
 
   - **Byte-level** (`a`, `b`, optional `pa`/`pb` preamble):
     - `midea:a=0x7B,b=0xE0` — fixed "Power off" magic value.

--- a/README.md
+++ b/README.md
@@ -258,10 +258,21 @@ The `toggle` parameter can be 0 or 1 and is optional. It helps to distinguish be
 
 - **ac**: Some air conditioners use this protocol (at least Gorenie and MDV). Usually 16-bit command contains 4-bit mode, 4-bit fan speed, 4-bit temperature and some other bits. Requires `addr` and `cmd`.
 
-- **midea**: Midea-family AC protocol (48-bit). Used by Midea-OEM rebranders such as Pioneer System, Comfee, Kaysun, Trotec, Lennox, EAS Electric, MDV, and many no-name Chinese splits. The frame contains a fixed `0xB2` vendor marker, two payload bytes `a` and `b`, and inverse copies of all three. Required parameters: `a` (mode/fan/power byte) and `b` (temperature/swing byte) — exposed as raw bytes; the exact field layout is OEM-specific. Optional parameters: `pa` and `pb` for an OEM-specific "preamble" frame sent before the payload (observed on EAS Electric / Comfee mode-change commands; the AC ignores the second frame without the matching preamble). Examples:
-  - Single-frame: `midea:a=0x7B,b=0xE0` — a real "Power off" command from EAS Electric EADVA25NT2.
-  - Two-frame: `midea:a=0xBF,b=0xD0,pa=0xE0,pb=0x03` — Cool 26°C with mode-switch preamble.
-  Use `remote.learn_command` to capture the bytes for each combination of (mode, temp, fan) you want to control. The `auto-decode` step picks `midea` over `ac` whenever the vendor byte equals `0xB2`.
+- **midea**: Midea-family AC protocol (48-bit). Used by Midea-OEM rebranders such as Pioneer System, Comfee, Kaysun, Trotec, Lennox, EAS Electric, MDV, and many no-name Chinese splits. The frame contains a fixed `0xB2` vendor marker, two payload bytes `a` (mode/fan/power) and `b` (temperature/mode), plus inverse copies of all three. The `auto-decode` step picks `midea` over `ac` whenever the vendor byte equals `0xB2`.
+
+  **Two parameter forms** are supported (mutually exclusive):
+
+  - **Byte-level** (`a`, `b`, optional `pa`/`pb` preamble):
+    - `midea:a=0x7B,b=0xE0` — fixed "Power off" magic value.
+    - `midea:a=0xBF,b=0x70` — Cool 22°C, fan auto.
+    - `midea:a=0xBF,b=0x70,pa=0xE0,pb=0x03` — same with the Sleep-mode preamble.
+
+  - **Field-level** (human-readable; auto-derives `a`/`b` from the empirical Midea field map):
+    - `midea:mode=cool,temp=22,fan=auto` — defaults: `power=on`. Modes: `cool`, `heat`, `auto`. Temps: 17–30°C. Fans: `auto`, `low`, `med`, `high` (ignored when `mode=auto`).
+    - `midea:power=off` — power off shortcut (returns the magic bytes).
+    - `midea:mode=cool,temp=22,sleep=on` — same as above but with the standard sleep preamble (`pa=0xE0,pb=0x03`).
+
+  Field semantics were derived empirically from EAS Electric EADVA25NT2 captures and matched against the IRremoteESP8266 4-bit Gray-coded temperature table. They should work for any Midea-OEM 48-bit-variant remote, but if your AC ignores the field-level command, capture the raw bytes via `remote.learn_command` and use the byte-level form. The `dry` and `fan` modes are not yet mapped (only the bit slot 0b01 in the mode field remains unobserved).
 
 
 ## Sub-GHz Code Formatting

--- a/README.md
+++ b/README.md
@@ -268,11 +268,11 @@ The `toggle` parameter can be 0 or 1 and is optional. It helps to distinguish be
     - `midea:a=0xBF,b=0x70,pa=0xE0,pb=0x03` — same with the Sleep-mode preamble.
 
   - **Field-level** (human-readable; auto-derives `a`/`b` from the empirical Midea field map):
-    - `midea:mode=cool,temp=22,fan=auto` — defaults: `power=on`. Modes: `cool`, `heat`, `auto`. Temps: 17–30°C. Fans: `auto`, `low`, `med`, `high` (ignored when `mode=auto`).
+    - `midea:mode=cool,temp=22,fan=auto` — defaults: `power=on`. Modes: `cool`, `heat`, `auto`, `dry`, `fan`. Temps: 17–30°C. Fans: `auto`, `low`, `med`, `high`. In `auto` and `dry` modes the AC controls the fan and the user's `fan` value is ignored. In `fan` mode the user's `temp` is ignored.
     - `midea:power=off` — power off shortcut (returns the magic bytes).
     - `midea:mode=cool,temp=22,sleep=on` — same as above but with the standard sleep preamble (`pa=0xE0,pb=0x03`).
 
-  Field semantics were derived empirically from EAS Electric EADVA25NT2 captures and matched against the IRremoteESP8266 4-bit Gray-coded temperature table. They should work for any Midea-OEM 48-bit-variant remote, but if your AC ignores the field-level command, capture the raw bytes via `remote.learn_command` and use the byte-level form. The `dry` and `fan` modes are not yet mapped (only the bit slot 0b01 in the mode field remains unobserved).
+  Field semantics were derived empirically from EAS Electric EADVA25NT2 captures and matched against the IRremoteESP8266 4-bit Gray-coded temperature table. They should work for any Midea-OEM 48-bit-variant remote, but if your AC ignores the field-level command, capture the raw bytes via `remote.learn_command` and use the byte-level form.
 
 
 ## Sub-GHz Code Formatting

--- a/README.md
+++ b/README.md
@@ -258,7 +258,10 @@ The `toggle` parameter can be 0 or 1 and is optional. It helps to distinguish be
 
 - **ac**: Some air conditioners use this protocol (at least Gorenie and MDV). Usually 16-bit command contains 4-bit mode, 4-bit fan speed, 4-bit temperature and some other bits. Requires `addr` and `cmd`.
 
-- **midea**: Midea-family AC protocol (48-bit, packet repeated as-is). Used by Midea-OEM rebranders such as Pioneer System, Comfee, Kaysun, Trotec, Lennox, EAS Electric, MDV, and many no-name Chinese splits. The frame contains a fixed `0xB2` vendor marker, two payload bytes `a` and `b`, and inverse copies of all three. Requires `a` (mode/fan/power byte) and `b` (temperature/swing byte) — the exact field layout within these bytes is OEM-specific, so the integration exposes them as raw bytes and leaves the per-OEM mapping to the user. Use `remote.learn_command` to capture the bytes for each combination of (mode, temp, fan) you want to control. The `auto-decode` step picks `midea` over `ac` whenever the vendor byte equals `0xB2`. Sample: `midea:a=0x7B,b=0xE0` (a real "Power off" command from EAS Electric EADVA25NT2).
+- **midea**: Midea-family AC protocol (48-bit). Used by Midea-OEM rebranders such as Pioneer System, Comfee, Kaysun, Trotec, Lennox, EAS Electric, MDV, and many no-name Chinese splits. The frame contains a fixed `0xB2` vendor marker, two payload bytes `a` and `b`, and inverse copies of all three. Required parameters: `a` (mode/fan/power byte) and `b` (temperature/swing byte) — exposed as raw bytes; the exact field layout is OEM-specific. Optional parameters: `pa` and `pb` for an OEM-specific "preamble" frame sent before the payload (observed on EAS Electric / Comfee mode-change commands; the AC ignores the second frame without the matching preamble). Examples:
+  - Single-frame: `midea:a=0x7B,b=0xE0` — a real "Power off" command from EAS Electric EADVA25NT2.
+  - Two-frame: `midea:a=0xBF,b=0xD0,pa=0xE0,pb=0x03` — Cool 26°C with mode-switch preamble.
+  Use `remote.learn_command` to capture the bytes for each combination of (mode, temp, fan) you want to control. The `auto-decode` step picks `midea` over `ac` whenever the vendor byte equals `0xB2`.
 
 
 ## Sub-GHz Code Formatting

--- a/README.md
+++ b/README.md
@@ -272,7 +272,12 @@ The `toggle` parameter can be 0 or 1 and is optional. It helps to distinguish be
     - `midea:power=off` — power off shortcut (returns the magic bytes).
     - `midea:mode=cool,temp=22,sleep=on` — same as above but with the standard sleep preamble (`pa=0xE0,pb=0x03`).
 
-  Field semantics were derived empirically from EAS Electric EADVA25NT2 captures and matched against the IRremoteESP8266 4-bit Gray-coded temperature table. They should work for any Midea-OEM 48-bit-variant remote, but if your AC ignores the field-level command, capture the raw bytes via `remote.learn_command` and use the byte-level form.
+  - **Button-level** (toggle/special commands that don't carry mode/temp state):
+    - `midea:button=swing` — toggle vertical swing.
+    - `midea:button=turbo` — turbo cooling/heating for ~10 minutes, then returns to previous state.
+    - `midea:button=led` — toggle the indoor unit's display panel and beep.
+
+  Field semantics were derived empirically from EAS Electric EADVA25NT2 captures and matched against the IRremoteESP8266 4-bit Gray-coded temperature table. They should work for any Midea-OEM 48-bit-variant remote, but if your AC ignores the field-level command, capture the raw bytes via `remote.learn_command` and use the byte-level form. Button commands use a second vendor byte (`0xB5` instead of `0xB2`) for turbo and led; auto-decode reports them as `midea:button=...`.
 
 
 ## Sub-GHz Code Formatting

--- a/custom_components/flipper_rc/rc_encoder.py
+++ b/custom_components/flipper_rc/rc_encoder.py
@@ -613,15 +613,31 @@ MIDEA_TEMP_REVERSE = {v: k for k, v in MIDEA_TEMP_GRAY.items()}
 
 MIDEA_MODE_BITS = {
     "cool": 0b00,
-    "auto": 0b10,
     "heat": 0b11,
-    # "dry" and "fan" not yet observed; their bit values likely complete
-    # the 2-bit space (0b01 is the only remaining slot).
+    "auto": 0b10,
+    # Both "dry" and "fan" share mode_bits=0b01 — they're disambiguated
+    # by fan_bits in byte a:
+    #   dry:  mode_bits=01 + fan_bits=000 (locked, AC decides)
+    #   fan:  mode_bits=01 + fan_bits=any (user-selectable, like cool/heat)
+    "dry":  0b01,
+    "fan":  0b01,
 }
-MIDEA_MODE_REVERSE = {v: k for k, v in MIDEA_MODE_BITS.items()}
+# Note: MIDEA_MODE_REVERSE intentionally NOT a simple dict-reverse —
+# `dry` and `fan` collide on 0b01 and need fan_bits to disambiguate.
 
-# Fan encoding for cool/heat modes (bits 7..5 of a). In auto mode the
-# remote forces the fan code to 0b000 — the AC decides fan speed itself.
+# Modes that force the fan-bits field to 0b000 regardless of any user-
+# supplied `fan` value. In these modes the remote signals "AC chooses
+# fan speed" by zeroing out the fan field.
+MIDEA_FAN_LOCKED_MODES = {"auto", "dry"}
+
+# Modes that ignore temperature: the temp Gray-code field is set to a
+# sentinel (0xE) that doesn't map to any value in the 17..30°C table.
+MIDEA_TEMP_IGNORED_MODES = {"fan"}
+MIDEA_TEMP_SENTINEL = 0xE
+
+# Fan encoding for cool/heat/fan modes (bits 7..5 of byte a). For modes
+# in MIDEA_FAN_LOCKED_MODES, the wire field is forced to 0b000 — the
+# user's fan choice is ignored.
 MIDEA_FAN_BITS = {
     "auto": 0b101,
     "low":  0b100,
@@ -747,17 +763,25 @@ def _midea_fields_to_bytes(mode=None, temp=None, fan=None, power=None):
         )
     mode_bits = MIDEA_MODE_BITS[mode_key]
 
-    if temp is None:
-        temp = 22
-    temp_int = int(temp)
-    if temp_int not in MIDEA_TEMP_GRAY:
-        raise ValueError(
-            f"Midea: temp {temp_int} out of supported range 17-30"
-        )
-    temp_gray = MIDEA_TEMP_GRAY[temp_int]
+    if mode_key in MIDEA_TEMP_IGNORED_MODES:
+        # "fan" mode doesn't carry a real temperature — the remote sends
+        # a sentinel value (0xE, outside the 17..30°C Gray code range).
+        if temp is not None:
+            # Caller supplied temp; ignore it but don't error out.
+            pass
+        temp_gray = MIDEA_TEMP_SENTINEL
+    else:
+        if temp is None:
+            temp = 22
+        temp_int = int(temp)
+        if temp_int not in MIDEA_TEMP_GRAY:
+            raise ValueError(
+                f"Midea: temp {temp_int} out of supported range 17-30"
+            )
+        temp_gray = MIDEA_TEMP_GRAY[temp_int]
 
-    if mode_key == "auto":
-        # Auto mode locks fan to "AC decides"; the wire bits are 0b000.
+    if mode_key in MIDEA_FAN_LOCKED_MODES:
+        # auto / dry: AC decides fan speed; the wire field is forced to 0b000.
         fan_bits = 0b000
     else:
         if fan is None:
@@ -796,20 +820,33 @@ def midea_bytes_to_fields(a, b):
     unknown = []
 
     mode_bits = (b >> 2) & 0b11
-    if mode_bits in MIDEA_MODE_REVERSE:
-        fields["mode"] = MIDEA_MODE_REVERSE[mode_bits]
+    fan_bits = (a >> 5) & 0b111
+    temp_gray = (b >> 4) & 0xF
+
+    # Mode disambiguation: bits 3..2 of b carry 4 distinct main modes,
+    # but 0b01 is shared between dry and fan — fan_bits in `a` resolves
+    # the ambiguity (dry forces fan to 000, fan-mode allows any value).
+    if mode_bits == 0b00:
+        fields["mode"] = "cool"
+    elif mode_bits == 0b10:
+        fields["mode"] = "auto"
+    elif mode_bits == 0b11:
+        fields["mode"] = "heat"
+    elif mode_bits == 0b01:
+        fields["mode"] = "dry" if fan_bits == 0b000 else "fan"
     else:
         unknown.append(f"mode_bits=0b{mode_bits:02b}")
 
-    temp_gray = (b >> 4) & 0xF
-    if temp_gray in MIDEA_TEMP_REVERSE:
+    if fields.get("mode") in MIDEA_TEMP_IGNORED_MODES:
+        # "fan" mode reports temp_gray=0xE (sentinel); skip temp.
+        pass
+    elif temp_gray in MIDEA_TEMP_REVERSE:
         fields["temp"] = MIDEA_TEMP_REVERSE[temp_gray]
     else:
         unknown.append(f"temp_gray=0x{temp_gray:X}")
 
-    fan_bits = (a >> 5) & 0b111
-    if fields.get("mode") == "auto":
-        fields["fan"] = "auto"
+    if fields.get("mode") in MIDEA_FAN_LOCKED_MODES:
+        fields["fan"] = "auto"  # AC-controlled
     elif fan_bits in MIDEA_FAN_REVERSE:
         fields["fan"] = MIDEA_FAN_REVERSE[fan_bits]
     else:

--- a/custom_components/flipper_rc/rc_encoder.py
+++ b/custom_components/flipper_rc/rc_encoder.py
@@ -584,6 +584,61 @@ MIDEA_INTER_GAP = 5100
 MIDEA_VENDOR_MSB = 0xB2  # B0 in MSB-first reading
 MIDEA_HALF_LEN = 99      # 1 leading_pulse + 1 leading_gap + 48*2 bit ticks + 1 closing_pulse
 
+# Field-level encoding tables, derived empirically from EAS Electric
+# EADVA25NT2 captures and matched against the IRremoteESP8266 Midea
+# 4-bit Gray-coded temperature table.
+#
+# Byte b (MSB):
+#     bits 7..4 — Gray-coded temperature (17..30°C)
+#     bits 3..2 — mode
+#     bits 1..0 — always 0 in observed samples
+#
+# Byte a (MSB):
+#     bits 7..5 — fan code (in cool/heat); auto-mode forces 0b000
+#     bit  4    — always 1 when on
+#     bit  3    — always 1
+#     bit  2    — power (1 = on, 0 = off)
+#     bit  1    — always 1
+#     bit  0    — always 1
+#
+# "Power off" is sent as a fixed magic value (0x7B, 0xE0); this matches
+# what the original remote emits and the AC accepts. Some commands (e.g.
+# enabling Sleep mode) require an additional preamble frame (0xE0, 0x03)
+# transmitted before the state frame.
+MIDEA_TEMP_GRAY = {
+    17: 0x0, 18: 0x1, 19: 0x3, 20: 0x2, 21: 0x6, 22: 0x7, 23: 0x5,
+    24: 0x4, 25: 0xC, 26: 0xD, 27: 0x9, 28: 0x8, 29: 0xA, 30: 0xB,
+}
+MIDEA_TEMP_REVERSE = {v: k for k, v in MIDEA_TEMP_GRAY.items()}
+
+MIDEA_MODE_BITS = {
+    "cool": 0b00,
+    "auto": 0b10,
+    "heat": 0b11,
+    # "dry" and "fan" not yet observed; their bit values likely complete
+    # the 2-bit space (0b01 is the only remaining slot).
+}
+MIDEA_MODE_REVERSE = {v: k for k, v in MIDEA_MODE_BITS.items()}
+
+# Fan encoding for cool/heat modes (bits 7..5 of a). In auto mode the
+# remote forces the fan code to 0b000 — the AC decides fan speed itself.
+MIDEA_FAN_BITS = {
+    "auto": 0b101,
+    "low":  0b100,
+    "med":  0b010,
+    "high": 0b001,
+}
+MIDEA_FAN_REVERSE = {v: k for k, v in MIDEA_FAN_BITS.items()}
+
+# Magic bytes for the "power off" command.
+MIDEA_OFF_A = 0x7B
+MIDEA_OFF_B = 0xE0
+
+# Preamble for the Sleep-mode toggle. Observed prepended to a normal
+# state frame whenever the user pressed the Sleep button on the remote.
+MIDEA_SLEEP_PA = 0xE0
+MIDEA_SLEEP_PB = 0x03
+
 def midea_decode(values):
     """Decode a 48-bit Midea AC packet (with one repetition).
 
@@ -650,6 +705,121 @@ def midea_decode(values):
         return f"a=0x{a:02X},b=0x{b:02X},pa=0x{pa:02X},pb=0x{pb:02X}"
     return f"a=0x{a:02X},b=0x{b:02X}"
 
+def _midea_normalize_bool(value, name):
+    """Coerce on/off/1/0/true/false (str/int/bool) into bool."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        s = value.strip().lower()
+        if s in ("on", "1", "true", "yes"):
+            return True
+        if s in ("off", "0", "false", "no"):
+            return False
+    raise ValueError(f"Midea: unsupported value for {name}: {value!r}")
+
+
+def _midea_fields_to_bytes(mode=None, temp=None, fan=None, power=None):
+    """Convert Midea (mode, temp, fan, power) into the (a, b) payload bytes.
+
+    Defaults: mode='cool', temp=22, fan='auto', power='on'. When power=off
+    the magic off command is returned regardless of other parameters.
+    """
+    if power is None:
+        power_on = True
+    else:
+        power_on = _midea_normalize_bool(power, "power")
+
+    if not power_on:
+        return MIDEA_OFF_A, MIDEA_OFF_B
+
+    if mode is None:
+        mode = "cool"
+    if isinstance(mode, str):
+        mode_key = mode.strip().lower()
+    else:
+        raise ValueError(f"Midea: mode must be a string, got {mode!r}")
+    if mode_key not in MIDEA_MODE_BITS:
+        raise ValueError(
+            f"Midea: unsupported mode {mode!r}, expected one of "
+            f"{sorted(MIDEA_MODE_BITS)}"
+        )
+    mode_bits = MIDEA_MODE_BITS[mode_key]
+
+    if temp is None:
+        temp = 22
+    temp_int = int(temp)
+    if temp_int not in MIDEA_TEMP_GRAY:
+        raise ValueError(
+            f"Midea: temp {temp_int} out of supported range 17-30"
+        )
+    temp_gray = MIDEA_TEMP_GRAY[temp_int]
+
+    if mode_key == "auto":
+        # Auto mode locks fan to "AC decides"; the wire bits are 0b000.
+        fan_bits = 0b000
+    else:
+        if fan is None:
+            fan = "auto"
+        if isinstance(fan, str):
+            fan_key = fan.strip().lower()
+        else:
+            raise ValueError(f"Midea: fan must be a string, got {fan!r}")
+        if fan_key not in MIDEA_FAN_BITS:
+            raise ValueError(
+                f"Midea: unsupported fan {fan!r}, expected one of "
+                f"{sorted(MIDEA_FAN_BITS)}"
+            )
+        fan_bits = MIDEA_FAN_BITS[fan_key]
+
+    # Bits 4,3,1,0 of `a` are always 1 in observed samples; bit 2 is power.
+    # Result: lower 5 bits = 0b11111 = 0x1F when on.
+    a = (fan_bits << 5) | 0x1F
+    # Bits 1,0 of `b` are always 0 in observed samples; bits 3,2 = mode.
+    b = (temp_gray << 4) | (mode_bits << 2)
+    return a, b
+
+
+def midea_bytes_to_fields(a, b):
+    """Decode (a, b) bytes into a dict of (mode, temp, fan, power) fields.
+
+    Returns a dict of recognized fields plus, for unrecognized bit
+    patterns, an `unknown` list with the offending field names. Useful
+    for diagnostics: the 'a/b' interface is the source of truth, this
+    helper just gives you semantic context.
+    """
+    if a == MIDEA_OFF_A and b == MIDEA_OFF_B:
+        return {"power": False}
+
+    fields = {"power": bool((a >> 2) & 1)}
+    unknown = []
+
+    mode_bits = (b >> 2) & 0b11
+    if mode_bits in MIDEA_MODE_REVERSE:
+        fields["mode"] = MIDEA_MODE_REVERSE[mode_bits]
+    else:
+        unknown.append(f"mode_bits=0b{mode_bits:02b}")
+
+    temp_gray = (b >> 4) & 0xF
+    if temp_gray in MIDEA_TEMP_REVERSE:
+        fields["temp"] = MIDEA_TEMP_REVERSE[temp_gray]
+    else:
+        unknown.append(f"temp_gray=0x{temp_gray:X}")
+
+    fan_bits = (a >> 5) & 0b111
+    if fields.get("mode") == "auto":
+        fields["fan"] = "auto"
+    elif fan_bits in MIDEA_FAN_REVERSE:
+        fields["fan"] = MIDEA_FAN_REVERSE[fan_bits]
+    else:
+        unknown.append(f"fan_bits=0b{fan_bits:03b}")
+
+    if unknown:
+        fields["unknown"] = unknown
+    return fields
+
+
 def _midea_pack(a, b):
     """Pack a 48-bit Midea packet for payload bytes (a, b) in MSB convention."""
     bytes_msb = [
@@ -664,23 +834,51 @@ def _midea_pack(a, b):
         48, msb_first=True,
     )
 
-def midea_encode(a, b, pa=None, pb=None):
-    """Encode a Midea AC command from one or two payload frames.
+def midea_encode(a=None, b=None, pa=None, pb=None,
+                 mode=None, temp=None, fan=None, power=None, sleep=None):
+    """Encode a Midea AC command.
 
-    Parameters:
-        a, b: payload bytes of the command frame (MSB convention).
-        pa, pb: optional preamble frame, sent BEFORE the command. Some
-            Midea-OEM remotes (observed on EAS Electric / Comfee mode-
-            change buttons) require a preamble announcing the new mode
-            before the payload is accepted. If only a/b are provided,
-            the simple two-repeat form is used.
+    Two parameter forms (mutually exclusive):
+        Byte-level:  pass `a` and `b` (raw payload bytes).
+        Field-level: pass `mode` ("cool"/"heat"/"auto"), `temp` (17-30),
+                     `fan` ("auto"/"low"/"med"/"high"), and `power`
+                     ("on"/"off"). Sensible defaults apply.
+
+    Optional preamble frame (sent before the state frame):
+        pa/pb: explicit preamble bytes.
+        sleep: shorthand — when truthy, prepends the standard sleep
+               preamble (0xE0, 0x03). Mutually exclusive with pa/pb.
     """
+    field_form = any(v is not None for v in (mode, temp, fan, power))
+    byte_form = a is not None or b is not None
+    if field_form and byte_form:
+        raise ValueError(
+            "Midea: pass either (a,b) or (mode,temp,fan,power), not both"
+        )
+
+    if field_form:
+        a, b = _midea_fields_to_bytes(
+            mode=mode, temp=temp, fan=fan, power=power
+        )
+    elif a is None or b is None:
+        raise ValueError(
+            "Midea: must provide either (a,b) or field-level parameters"
+        )
+
     if not (0x00 <= a <= 0xFF):
         raise ValueError("Midea: 'a' must be in range 0x00-0xFF")
     if not (0x00 <= b <= 0xFF):
         raise ValueError("Midea: 'b' must be in range 0x00-0xFF")
     if (pa is None) != (pb is None):
         raise ValueError("Midea: 'pa' and 'pb' must be provided together")
+
+    if sleep is not None:
+        if _midea_normalize_bool(sleep, "sleep"):
+            if pa is not None or pb is not None:
+                raise ValueError(
+                    "Midea: cannot use both `sleep=on` and explicit pa/pb"
+                )
+            pa, pb = MIDEA_SLEEP_PA, MIDEA_SLEEP_PB
 
     cmd_packet = _midea_pack(a, b)
 
@@ -770,15 +968,24 @@ def rc_auto_encode(s):
         ValueError: If the input string is not in the correct format, or if the format identifier
                     is unknown.
     """
+    def _coerce(v):
+        # Try int first (handles 0xAB, 0b101, 42); fall back to the raw
+        # string so encoders that accept named parameters (e.g. midea
+        # mode="cool") receive them unchanged.
+        try:
+            return int(v, 0)
+        except (ValueError, TypeError):
+            return v
+
     try:
         fmt, data = s.split(":", 1)
         if fmt == "raw":
             return [int(v, 0) for v in data.split(",")]
         if fmt == "tuya":
-            return data # raw base64 Tuya-format
+            return data  # raw base64 Tuya-format
         data = dict(v.split("=") for v in data.split(","))
-        data = {k: int(v, 0) for k, v in data.items()}
-    except:
+        data = {k: _coerce(v) for k, v in data.items()}
+    except Exception:
         raise ValueError(f"Invalid command format: {s}")
     if fmt not in RC_CONVERTERS:
         raise ValueError(f"Unknown format: {fmt}")

--- a/custom_components/flipper_rc/rc_encoder.py
+++ b/custom_components/flipper_rc/rc_encoder.py
@@ -581,8 +581,29 @@ MIDEA_PULSE = 560
 MIDEA_GAP_0 = 560
 MIDEA_GAP_1 = 1690
 MIDEA_INTER_GAP = 5100
-MIDEA_VENDOR_MSB = 0xB2  # B0 in MSB-first reading
+MIDEA_VENDOR_MSB = 0xB2          # State commands (cool/heat/auto/dry/fan)
+MIDEA_SPECIAL_VENDOR_MSB = 0xB5  # Special toggle commands (turbo, LED, ...)
 MIDEA_HALF_LEN = 99      # 1 leading_pulse + 1 leading_gap + 48*2 bit ticks + 1 closing_pulse
+
+# Magic byte values for the user-facing toggle buttons. Captured from
+# an EAS Electric EADVA25NT2 remote; same values are reported to work on
+# other Midea-OEM AC remotes that share the 48-bit-no-bit-inversion
+# variant. Each entry is `(vendor, a, b)` in MSB convention.
+#
+# - swing: travels on the regular state-command vendor (0xB2). The AC
+#          interprets these specific bytes as "toggle vertical swing"
+#          regardless of current state.
+# - turbo: special-vendor (0xB5) command. Pressing once enables turbo
+#          for ~10 minutes; pressing again returns to previous state.
+# - led:   special-vendor (0xB5) command. Toggles the indoor unit's
+#          display panel and confirmation beep.
+MIDEA_BUTTONS = {
+    "swing": (MIDEA_VENDOR_MSB,         0x6B, 0xE0),
+    "turbo": (MIDEA_SPECIAL_VENDOR_MSB, 0xF5, 0xA2),
+    "led":   (MIDEA_SPECIAL_VENDOR_MSB, 0xF5, 0xA5),
+}
+# Reverse map for decoding: (vendor, a, b) → button name.
+MIDEA_BUTTONS_REVERSE = {v: k for k, v in MIDEA_BUTTONS.items()}
 
 # Field-level encoding tables, derived empirically from EAS Electric
 # EADVA25NT2 captures and matched against the IRremoteESP8266 Midea
@@ -678,11 +699,12 @@ def midea_decode(values):
             raise ValueError("Midea: invalid inverse pair (B2/B3)")
         if data[4] != data[5] ^ 0xFF:
             raise ValueError("Midea: invalid inverse pair (B4/B5)")
-        if data[0] != MIDEA_VENDOR_MSB:
+        if data[0] not in (MIDEA_VENDOR_MSB, MIDEA_SPECIAL_VENDOR_MSB):
             raise ValueError(
-                f"Midea: vendor byte expected 0x{MIDEA_VENDOR_MSB:02X}, got 0x{data[0]:02X}"
+                f"Midea: vendor byte expected 0x{MIDEA_VENDOR_MSB:02X} or "
+                f"0x{MIDEA_SPECIAL_VENDOR_MSB:02X}, got 0x{data[0]:02X}"
             )
-        return data[2], data[4]
+        return data[0], data[2], data[4]
 
     # The signal contains one or more 48-bit packets, each occupying exactly
     # MIDEA_HALF_LEN elements (1 leading_pulse + 1 leading_gap + 48*2 bit
@@ -713,11 +735,22 @@ def midea_decode(values):
     # frames precede it, redundancy repeats follow it. If all packets are
     # identical we return them; if there's a leading preamble that differs,
     # we still take the last (which is the state the AC should land in).
-    a, b = packets[-1]
+    last = packets[-1]
+
+    # Special-vendor (0xB5) packets are toggle-style buttons (turbo, LED,
+    # etc.). They don't carry mode/temp state, so report them as `button=`.
+    if last in MIDEA_BUTTONS_REVERSE:
+        return f"button={MIDEA_BUTTONS_REVERSE[last]}"
+
+    vendor, a, b = last
+    if vendor == MIDEA_SPECIAL_VENDOR_MSB:
+        # Special-vendor packet we don't have a name for; expose raw bytes.
+        return f"button=unknown,a=0x{a:02X},b=0x{b:02X}"
+
     if len(packets) > 1 and packets[0] != packets[-1]:
-        # There's a preamble. Expose it via a `preamble=` annotation so the
+        # There's a preamble. Expose it via a `pa`/`pb` annotation so the
         # encoder can faithfully reproduce the original two-frame sequence.
-        pa, pb = packets[0]
+        _, pa, pb = packets[0]
         return f"a=0x{a:02X},b=0x{b:02X},pa=0x{pa:02X},pb=0x{pb:02X}"
     return f"a=0x{a:02X},b=0x{b:02X}"
 
@@ -857,10 +890,15 @@ def midea_bytes_to_fields(a, b):
     return fields
 
 
-def _midea_pack(a, b):
-    """Pack a 48-bit Midea packet for payload bytes (a, b) in MSB convention."""
+def _midea_pack(a, b, vendor=MIDEA_VENDOR_MSB):
+    """Pack a 48-bit Midea packet for payload bytes (a, b) in MSB convention.
+
+    `vendor` selects the leading vendor/Type byte: MIDEA_VENDOR_MSB (0xB2)
+    for state commands (the default), MIDEA_SPECIAL_VENDOR_MSB (0xB5) for
+    special toggle commands like Turbo / LED.
+    """
     bytes_msb = [
-        MIDEA_VENDOR_MSB, MIDEA_VENDOR_MSB ^ 0xFF,
+        vendor, vendor ^ 0xFF,
         a & 0xFF, (a ^ 0xFF) & 0xFF,
         b & 0xFF, (b ^ 0xFF) & 0xFF,
     ]
@@ -872,26 +910,50 @@ def _midea_pack(a, b):
     )
 
 def midea_encode(a=None, b=None, pa=None, pb=None,
-                 mode=None, temp=None, fan=None, power=None, sleep=None):
+                 mode=None, temp=None, fan=None, power=None, sleep=None,
+                 button=None):
     """Encode a Midea AC command.
 
-    Two parameter forms (mutually exclusive):
-        Byte-level:  pass `a` and `b` (raw payload bytes).
-        Field-level: pass `mode` ("cool"/"heat"/"auto"), `temp` (17-30),
-                     `fan` ("auto"/"low"/"med"/"high"), and `power`
-                     ("on"/"off"). Sensible defaults apply.
+    Three mutually-exclusive parameter forms:
+        Byte-level:   pass `a` and `b` (raw payload bytes).
+        Field-level:  pass `mode` ("cool"/"heat"/"auto"/"dry"/"fan"),
+                      `temp` (17-30), `fan` ("auto"/"low"/"med"/"high"),
+                      and `power` ("on"/"off"). Sensible defaults apply.
+        Button-level: pass `button` ("swing"/"turbo"/"led") for one of
+                      the toggle/special commands. The vendor byte and
+                      payload are looked up from `MIDEA_BUTTONS`.
 
-    Optional preamble frame (sent before the state frame):
-        pa/pb: explicit preamble bytes.
+    Optional (only valid with byte- and field-level forms):
+        pa/pb: explicit preamble bytes (sent BEFORE the state frame).
         sleep: shorthand — when truthy, prepends the standard sleep
                preamble (0xE0, 0x03). Mutually exclusive with pa/pb.
     """
     field_form = any(v is not None for v in (mode, temp, fan, power))
     byte_form = a is not None or b is not None
-    if field_form and byte_form:
+    button_form = button is not None
+    forms_used = [field_form, byte_form, button_form]
+    if sum(forms_used) > 1:
         raise ValueError(
-            "Midea: pass either (a,b) or (mode,temp,fan,power), not both"
+            "Midea: choose only one of (a,b), (mode,...) or button=..."
         )
+
+    if button_form:
+        if pa is not None or pb is not None or sleep is not None:
+            raise ValueError(
+                "Midea: button commands do not support pa/pb/sleep"
+            )
+        if isinstance(button, str):
+            button_key = button.strip().lower()
+        else:
+            raise ValueError(f"Midea: button must be a string, got {button!r}")
+        if button_key not in MIDEA_BUTTONS:
+            raise ValueError(
+                f"Midea: unknown button {button!r}, expected one of "
+                f"{sorted(MIDEA_BUTTONS)}"
+            )
+        vendor, btn_a, btn_b = MIDEA_BUTTONS[button_key]
+        packet = _midea_pack(btn_a, btn_b, vendor=vendor)
+        return packet + [MIDEA_INTER_GAP] + packet
 
     if field_form:
         a, b = _midea_fields_to_bytes(
@@ -899,7 +961,7 @@ def midea_encode(a=None, b=None, pa=None, pb=None,
         )
     elif a is None or b is None:
         raise ValueError(
-            "Midea: must provide either (a,b) or field-level parameters"
+            "Midea: must provide either (a,b), field-level params, or button=..."
         )
 
     if not (0x00 <= a <= 0xFF):

--- a/custom_components/flipper_rc/rc_encoder.py
+++ b/custom_components/flipper_rc/rc_encoder.py
@@ -494,6 +494,9 @@ AC_PULSE = 560
 AC_GAP_0 = 560
 AC_GAP_1 = 1690
 
+# Gap between the two repeated 48-bit packets in Midea-family protocols.
+AC_INTER_PACKET_GAP = 5100
+
 def air_conditioner_decode(values):
     if len(values) < 100:
         raise ValueError("Invalid AC data: too short")
@@ -536,6 +539,124 @@ def air_conditioner_encode(addr, cmd, double=0, closing=NEC_GAP_0):
     return v
 
 
+"""
+Midea AC protocol (48-bit, packet repeated as-is, no inter-packet inversion).
+
+This is the variant used by Midea-OEM rebranders such as EAS Electric, MDV,
+Comfee, Pioneer System, Kaysun, Trotec, Lennox, and many no-name Chinese
+splits. It differs from the IRremoteESP8266 "Midea" protocol (which sends
+the second 48-bit packet bit-inverted); here both packets are identical.
+
+Frame structure (MSB-first on the wire):
+    Byte 0: 0xB2  - Midea AC vendor marker (always)
+    Byte 1: 0x4D  - inverse of byte 0
+    Byte 2: payload byte A (mode + fan + power, exact mapping is OEM-specific)
+    Byte 3: ~A   - inverse
+    Byte 4: payload byte B (temperature + swing/sleep flags)
+    Byte 5: ~B   - inverse
+
+Useful payload is just 16 bits (A and B). The flipper_rc API exposes them
+as `a` and `b` so any Midea-family AC can be controlled once two raw
+samples have been captured and mapped to (mode, temp, fan, power) on a
+case-by-case basis. A field-level helper can be added on top once the
+OEM-specific mapping is known.
+
+Wire format (timings in µs):
+    Header pulse: ~4500
+    Header gap:   ~4500
+    Bit-0:        ~560 pulse + ~560 gap
+    Bit-1:        ~560 pulse + ~1690 gap
+    Inter-packet gap: ~5100 (between the two identical 48-bit packets)
+    Closing pulse: ~560
+
+References:
+    - IRremoteESP8266 ir_Midea.h / ir_Midea.cpp
+    - Midea protocol spreadsheet:
+      https://docs.google.com/spreadsheets/d/1TZh4jWrx4h9zzpYUI9aYXMl1fYOiqu-xVuOOMqagxrs
+    - The 48-bit-only variant captured on EAS Electric EADVA25NT2 splits.
+"""
+MIDEA_LEADING_PULSE = 4500
+MIDEA_LEADING_GAP = 4500
+MIDEA_PULSE = 560
+MIDEA_GAP_0 = 560
+MIDEA_GAP_1 = 1690
+MIDEA_INTER_GAP = 5100
+MIDEA_VENDOR_MSB = 0xB2  # B0 in MSB-first reading
+MIDEA_HALF_LEN = 99      # 1 leading_pulse + 1 leading_gap + 48*2 bit ticks + 1 closing_pulse
+
+def midea_decode(values):
+    """Decode a 48-bit Midea AC packet (with one repetition).
+
+    Returns "a=0xXX,b=0xYY" on success. Raises ValueError if the signal
+    does not match the Midea structure (vendor byte, inverse-pair check,
+    matching repeated half).
+    """
+    if len(values) < MIDEA_HALF_LEN:
+        raise ValueError(f"Midea: too short, need at least {MIDEA_HALF_LEN} elements")
+
+    def decode_half(half):
+        data = pulse.distance_decode(
+            half,
+            MIDEA_LEADING_PULSE, MIDEA_LEADING_GAP,
+            MIDEA_PULSE, MIDEA_GAP_0, MIDEA_GAP_1,
+            48, msb_first=True,
+        )
+        if data[0] != data[1] ^ 0xFF:
+            raise ValueError("Midea: invalid inverse pair (B0/B1)")
+        if data[2] != data[3] ^ 0xFF:
+            raise ValueError("Midea: invalid inverse pair (B2/B3)")
+        if data[4] != data[5] ^ 0xFF:
+            raise ValueError("Midea: invalid inverse pair (B4/B5)")
+        if data[0] != MIDEA_VENDOR_MSB:
+            raise ValueError(
+                f"Midea: vendor byte expected 0x{MIDEA_VENDOR_MSB:02X}, got 0x{data[0]:02X}"
+            )
+        return data[2], data[4]
+
+    # The signal is two identical 48-bit packets separated by an inter-packet
+    # gap (~5100µs). The first packet always occupies exactly MIDEA_HALF_LEN
+    # elements (1 leading_pulse + 1 leading_gap + 48*2 bit ticks + 1 closing
+    # pulse), so there's no need to scan for the boundary.
+    half1 = values[:MIDEA_HALF_LEN]
+    a1, b1 = decode_half(half1)
+
+    # If a second packet was captured, validate that it matches the first.
+    # The element at index MIDEA_HALF_LEN is the inter-message gap; the
+    # second packet starts at MIDEA_HALF_LEN + 1.
+    if len(values) >= MIDEA_HALF_LEN * 2:
+        half2 = values[MIDEA_HALF_LEN + 1:]
+        if len(half2) >= MIDEA_HALF_LEN - 1:
+            a2, b2 = decode_half(half2)
+            if (a1, b1) != (a2, b2):
+                raise ValueError(
+                    f"Midea: repeated halves differ: "
+                    f"(0x{a1:02X},0x{b1:02X}) vs (0x{a2:02X},0x{b2:02X})"
+                )
+
+    return f"a=0x{a1:02X},b=0x{b1:02X}"
+
+def midea_encode(a, b):
+    """Encode a Midea AC command from two payload bytes (MSB convention)."""
+    if not (0x00 <= a <= 0xFF):
+        raise ValueError("Midea: 'a' must be in range 0x00-0xFF")
+    if not (0x00 <= b <= 0xFF):
+        raise ValueError("Midea: 'b' must be in range 0x00-0xFF")
+
+    bytes_msb = [
+        MIDEA_VENDOR_MSB, MIDEA_VENDOR_MSB ^ 0xFF,
+        a & 0xFF, (a ^ 0xFF) & 0xFF,
+        b & 0xFF, (b ^ 0xFF) & 0xFF,
+    ]
+    half = pulse.distance_encode(
+        bytes_msb,
+        MIDEA_LEADING_PULSE, MIDEA_LEADING_GAP,
+        MIDEA_PULSE, MIDEA_GAP_0, MIDEA_GAP_1,
+        48, msb_first=True,
+    )
+    # Repeat the packet verbatim with an inter-packet gap.
+    return half + [MIDEA_INTER_GAP] + half
+
+
 # Dictionary of supported RC converters
 RC_CONVERTERS = {
     "nec42": (nec42_encode, nec42_decode),
@@ -551,6 +672,7 @@ RC_CONVERTERS = {
     "kaseikyo": (kaseikyo_encode, kaseikyo_decode),
     "rca": (rca_encode, rca_decode),
     "pioneer": (pioneer_encode, pioneer_decode),
+    "midea": (midea_encode, midea_decode),
     "ac": (air_conditioner_encode, air_conditioner_decode),
 }
 

--- a/custom_components/flipper_rc/rc_encoder.py
+++ b/custom_components/flipper_rc/rc_encoder.py
@@ -613,48 +613,93 @@ def midea_decode(values):
             )
         return data[2], data[4]
 
-    # The signal is two identical 48-bit packets separated by an inter-packet
-    # gap (~5100µs). The first packet always occupies exactly MIDEA_HALF_LEN
-    # elements (1 leading_pulse + 1 leading_gap + 48*2 bit ticks + 1 closing
-    # pulse), so there's no need to scan for the boundary.
-    half1 = values[:MIDEA_HALF_LEN]
-    a1, b1 = decode_half(half1)
+    # The signal contains one or more 48-bit packets, each occupying exactly
+    # MIDEA_HALF_LEN elements (1 leading_pulse + 1 leading_gap + 48*2 bit
+    # ticks + 1 closing pulse), separated by ~5100µs inter-packet gaps.
+    #
+    # Some Midea remotes send a single payload packet repeated twice for
+    # redundancy. Others (observed on EAS Electric / Comfee mode-switch
+    # commands) send a "preamble" packet first, followed by the actual
+    # state packet repeated twice. Total length is therefore either
+    # MIDEA_HALF_LEN * N + (N-1) for N packets.
+    packets = []
+    pos = 0
+    while pos + MIDEA_HALF_LEN <= len(values):
+        try:
+            packets.append(decode_half(values[pos:pos + MIDEA_HALF_LEN]))
+        except ValueError:
+            # Stop on first malformed packet (e.g., truncated capture).
+            break
+        # Skip the inter-packet gap (1 element) before the next packet.
+        pos += MIDEA_HALF_LEN + 1
 
-    # If a second packet was captured, validate that it matches the first.
-    # The element at index MIDEA_HALF_LEN is the inter-message gap; the
-    # second packet starts at MIDEA_HALF_LEN + 1.
-    if len(values) >= MIDEA_HALF_LEN * 2:
-        half2 = values[MIDEA_HALF_LEN + 1:]
-        if len(half2) >= MIDEA_HALF_LEN - 1:
-            a2, b2 = decode_half(half2)
-            if (a1, b1) != (a2, b2):
-                raise ValueError(
-                    f"Midea: repeated halves differ: "
-                    f"(0x{a1:02X},0x{b1:02X}) vs (0x{a2:02X},0x{b2:02X})"
-                )
+    if not packets:
+        # Re-raise the original error with full context.
+        decode_half(values[:MIDEA_HALF_LEN])  # raises
+        raise ValueError("Midea: no valid packets")  # unreachable
 
-    return f"a=0x{a1:02X},b=0x{b1:02X}"
+    # The "actual command" payload is the LAST distinct packet — preamble
+    # frames precede it, redundancy repeats follow it. If all packets are
+    # identical we return them; if there's a leading preamble that differs,
+    # we still take the last (which is the state the AC should land in).
+    a, b = packets[-1]
+    if len(packets) > 1 and packets[0] != packets[-1]:
+        # There's a preamble. Expose it via a `preamble=` annotation so the
+        # encoder can faithfully reproduce the original two-frame sequence.
+        pa, pb = packets[0]
+        return f"a=0x{a:02X},b=0x{b:02X},pa=0x{pa:02X},pb=0x{pb:02X}"
+    return f"a=0x{a:02X},b=0x{b:02X}"
 
-def midea_encode(a, b):
-    """Encode a Midea AC command from two payload bytes (MSB convention)."""
-    if not (0x00 <= a <= 0xFF):
-        raise ValueError("Midea: 'a' must be in range 0x00-0xFF")
-    if not (0x00 <= b <= 0xFF):
-        raise ValueError("Midea: 'b' must be in range 0x00-0xFF")
-
+def _midea_pack(a, b):
+    """Pack a 48-bit Midea packet for payload bytes (a, b) in MSB convention."""
     bytes_msb = [
         MIDEA_VENDOR_MSB, MIDEA_VENDOR_MSB ^ 0xFF,
         a & 0xFF, (a ^ 0xFF) & 0xFF,
         b & 0xFF, (b ^ 0xFF) & 0xFF,
     ]
-    half = pulse.distance_encode(
+    return pulse.distance_encode(
         bytes_msb,
         MIDEA_LEADING_PULSE, MIDEA_LEADING_GAP,
         MIDEA_PULSE, MIDEA_GAP_0, MIDEA_GAP_1,
         48, msb_first=True,
     )
-    # Repeat the packet verbatim with an inter-packet gap.
-    return half + [MIDEA_INTER_GAP] + half
+
+def midea_encode(a, b, pa=None, pb=None):
+    """Encode a Midea AC command from one or two payload frames.
+
+    Parameters:
+        a, b: payload bytes of the command frame (MSB convention).
+        pa, pb: optional preamble frame, sent BEFORE the command. Some
+            Midea-OEM remotes (observed on EAS Electric / Comfee mode-
+            change buttons) require a preamble announcing the new mode
+            before the payload is accepted. If only a/b are provided,
+            the simple two-repeat form is used.
+    """
+    if not (0x00 <= a <= 0xFF):
+        raise ValueError("Midea: 'a' must be in range 0x00-0xFF")
+    if not (0x00 <= b <= 0xFF):
+        raise ValueError("Midea: 'b' must be in range 0x00-0xFF")
+    if (pa is None) != (pb is None):
+        raise ValueError("Midea: 'pa' and 'pb' must be provided together")
+
+    cmd_packet = _midea_pack(a, b)
+
+    if pa is not None:
+        if not (0x00 <= pa <= 0xFF):
+            raise ValueError("Midea: 'pa' must be in range 0x00-0xFF")
+        if not (0x00 <= pb <= 0xFF):
+            raise ValueError("Midea: 'pb' must be in range 0x00-0xFF")
+        preamble = _midea_pack(pa, pb)
+        # Sequence: preamble + gap + command + gap + command (matches the
+        # 299-element multi-frame structure observed in real captures).
+        return (
+            preamble + [MIDEA_INTER_GAP]
+            + cmd_packet + [MIDEA_INTER_GAP]
+            + cmd_packet
+        )
+
+    # Single-frame command repeated twice for redundancy (199 elements).
+    return cmd_packet + [MIDEA_INTER_GAP] + cmd_packet
 
 
 # Dictionary of supported RC converters

--- a/custom_components/flipper_rc/rc_encoder.py
+++ b/custom_components/flipper_rc/rc_encoder.py
@@ -494,9 +494,6 @@ AC_PULSE = 560
 AC_GAP_0 = 560
 AC_GAP_1 = 1690
 
-# Gap between the two repeated 48-bit packets in Midea-family protocols.
-AC_INTER_PACKET_GAP = 5100
-
 def air_conditioner_decode(values):
     if len(values) < 100:
         raise ValueError("Invalid AC data: too short")
@@ -539,42 +536,43 @@ def air_conditioner_encode(addr, cmd, double=0, closing=NEC_GAP_0):
     return v
 
 
-"""
-Midea AC protocol (48-bit, packet repeated as-is, no inter-packet inversion).
-
-This is the variant used by Midea-OEM rebranders such as EAS Electric, MDV,
-Comfee, Pioneer System, Kaysun, Trotec, Lennox, and many no-name Chinese
-splits. It differs from the IRremoteESP8266 "Midea" protocol (which sends
-the second 48-bit packet bit-inverted); here both packets are identical.
-
-Frame structure (MSB-first on the wire):
-    Byte 0: 0xB2  - Midea AC vendor marker (always)
-    Byte 1: 0x4D  - inverse of byte 0
-    Byte 2: payload byte A (mode + fan + power, exact mapping is OEM-specific)
-    Byte 3: ~A   - inverse
-    Byte 4: payload byte B (temperature + swing/sleep flags)
-    Byte 5: ~B   - inverse
-
-Useful payload is just 16 bits (A and B). The flipper_rc API exposes them
-as `a` and `b` so any Midea-family AC can be controlled once two raw
-samples have been captured and mapped to (mode, temp, fan, power) on a
-case-by-case basis. A field-level helper can be added on top once the
-OEM-specific mapping is known.
-
-Wire format (timings in µs):
-    Header pulse: ~4500
-    Header gap:   ~4500
-    Bit-0:        ~560 pulse + ~560 gap
-    Bit-1:        ~560 pulse + ~1690 gap
-    Inter-packet gap: ~5100 (between the two identical 48-bit packets)
-    Closing pulse: ~560
-
-References:
-    - IRremoteESP8266 ir_Midea.h / ir_Midea.cpp
-    - Midea protocol spreadsheet:
-      https://docs.google.com/spreadsheets/d/1TZh4jWrx4h9zzpYUI9aYXMl1fYOiqu-xVuOOMqagxrs
-    - The 48-bit-only variant captured on EAS Electric EADVA25NT2 splits.
-"""
+# Midea AC protocol (48-bit, packet repeated as-is, no inter-packet inversion).
+#
+# This is the variant used by Midea-OEM rebranders such as EAS Electric, MDV,
+# Comfee, Pioneer System, Kaysun, Trotec, Lennox, and many no-name Chinese
+# splits. It differs from the IRremoteESP8266 "Midea" protocol (which sends
+# the second 48-bit packet bit-inverted); here both packets are identical.
+#
+# Frame structure (MSB-first on the wire):
+#     Byte 0: 0xB2 (state commands) or 0xB5 (special toggle commands like
+#             turbo / LED) — Midea AC vendor marker.
+#     Byte 1: inverse of byte 0 (0x4D for 0xB2, 0x4A for 0xB5).
+#     Byte 2: payload byte A (mode + fan + power for state commands;
+#             button magic for special-vendor commands).
+#     Byte 3: ~A   - inverse
+#     Byte 4: payload byte B (temperature + mode for state commands;
+#             button magic for special-vendor commands).
+#     Byte 5: ~B   - inverse
+#
+# Useful payload is just 16 bits (A and B). The flipper_rc API exposes both
+# byte-level (`a`/`b`) and field-level (`mode`/`temp`/`fan`/`power`) forms;
+# OEM-specific mappings can still vary slightly, so when a field-level
+# command is rejected by an AC, fall back to the byte-level form using
+# captured samples.
+#
+# Wire format (timings in µs):
+#     Header pulse: ~4500
+#     Header gap:   ~4500
+#     Bit-0:        ~560 pulse + ~560 gap
+#     Bit-1:        ~560 pulse + ~1690 gap
+#     Inter-packet gap: ~5100 (between the two identical 48-bit packets)
+#     Closing pulse: ~560
+#
+# References:
+#     - IRremoteESP8266 ir_Midea.h / ir_Midea.cpp
+#     - Midea protocol spreadsheet:
+#       https://docs.google.com/spreadsheets/d/1TZh4jWrx4h9zzpYUI9aYXMl1fYOiqu-xVuOOMqagxrs
+#     - The 48-bit-only variant captured on EAS Electric EADVA25NT2 splits.
 MIDEA_LEADING_PULSE = 4500
 MIDEA_LEADING_GAP = 4500
 MIDEA_PULSE = 560
@@ -721,7 +719,19 @@ def midea_decode(values):
         try:
             packets.append(decode_half(values[pos:pos + MIDEA_HALF_LEN]))
         except ValueError:
-            # Stop on first malformed packet (e.g., truncated capture).
+            # A whole-packet slice failed to decode. If we already collected
+            # at least one valid packet AND we're at the tail (less than a
+            # full packet remaining after this one), tolerate it as a
+            # truncated capture. Otherwise the signal is corrupted and we
+            # should not silently return whatever we got so far.
+            if not packets:
+                raise
+            remaining = len(values) - pos
+            if remaining >= MIDEA_HALF_LEN:
+                raise ValueError(
+                    "Midea: malformed packet at offset "
+                    f"{pos} (remaining={remaining})"
+                )
             break
         # Skip the inter-packet gap (1 element) before the next packet.
         pos += MIDEA_HALF_LEN + 1
@@ -731,11 +741,16 @@ def midea_decode(values):
         decode_half(values[:MIDEA_HALF_LEN])  # raises
         raise ValueError("Midea: no valid packets")  # unreachable
 
-    # The "actual command" payload is the LAST distinct packet — preamble
-    # frames precede it, redundancy repeats follow it. If all packets are
-    # identical we return them; if there's a leading preamble that differs,
-    # we still take the last (which is the state the AC should land in).
+    # Real captures always contain at least one repeated state packet (the
+    # AC ignores single-shot transmissions). Validate that the last two
+    # packets are identical — this both rejects corrupted captures and
+    # disambiguates "preamble + state(x2)" from "two unrelated frames".
     last = packets[-1]
+    if len(packets) >= 2 and packets[-2] != last:
+        raise ValueError(
+            "Midea: expected the trailing state packet to repeat, got "
+            f"{packets[-2]} != {last}"
+        )
 
     # Special-vendor (0xB5) packets are toggle-style buttons (turbo, LED,
     # etc.). They don't carry mode/temp state, so report them as `button=`.
@@ -796,38 +811,48 @@ def _midea_fields_to_bytes(mode=None, temp=None, fan=None, power=None):
         )
     mode_bits = MIDEA_MODE_BITS[mode_key]
 
-    if mode_key in MIDEA_TEMP_IGNORED_MODES:
-        # "fan" mode doesn't carry a real temperature — the remote sends
-        # a sentinel value (0xE, outside the 17..30°C Gray code range).
-        if temp is not None:
-            # Caller supplied temp; ignore it but don't error out.
-            pass
-        temp_gray = MIDEA_TEMP_SENTINEL
-    else:
-        if temp is None:
-            temp = 22
-        temp_int = int(temp)
+    # Always validate `temp` if supplied, even in modes that ignore it on
+    # the wire — silently accepting `temp=99` only to drop it would mask
+    # caller bugs. The validated value is then either encoded or replaced
+    # with the sentinel for fan-mode.
+    if temp is not None:
+        try:
+            temp_int = int(temp)
+        except (TypeError, ValueError):
+            raise ValueError(f"Midea: temp must be an integer, got {temp!r}")
         if temp_int not in MIDEA_TEMP_GRAY:
             raise ValueError(
                 f"Midea: temp {temp_int} out of supported range 17-30"
             )
+    else:
+        temp_int = 22  # default
+
+    if mode_key in MIDEA_TEMP_IGNORED_MODES:
+        # "fan" mode doesn't carry a real temperature — the remote sends
+        # a sentinel value (0xE, outside the 17..30°C Gray code range).
+        temp_gray = MIDEA_TEMP_SENTINEL
+    else:
         temp_gray = MIDEA_TEMP_GRAY[temp_int]
 
-    if mode_key in MIDEA_FAN_LOCKED_MODES:
-        # auto / dry: AC decides fan speed; the wire field is forced to 0b000.
-        fan_bits = 0b000
-    else:
-        if fan is None:
-            fan = "auto"
-        if isinstance(fan, str):
-            fan_key = fan.strip().lower()
-        else:
+    # Always validate `fan` if supplied, even in modes that lock it on the
+    # wire (auto/dry). The validated value is then either encoded or
+    # replaced with 0b000 (AC-controlled).
+    if fan is not None:
+        if not isinstance(fan, str):
             raise ValueError(f"Midea: fan must be a string, got {fan!r}")
+        fan_key = fan.strip().lower()
         if fan_key not in MIDEA_FAN_BITS:
             raise ValueError(
                 f"Midea: unsupported fan {fan!r}, expected one of "
                 f"{sorted(MIDEA_FAN_BITS)}"
             )
+    else:
+        fan_key = "auto"  # default
+
+    if mode_key in MIDEA_FAN_LOCKED_MODES:
+        # auto / dry: AC decides fan speed; the wire field is forced to 0b000.
+        fan_bits = 0b000
+    else:
         fan_bits = MIDEA_FAN_BITS[fan_key]
 
     # Bits 4,3,1,0 of `a` are always 1 in observed samples; bit 2 is power.
@@ -1082,10 +1107,14 @@ def rc_auto_encode(s):
             return [int(v, 0) for v in data.split(",")]
         if fmt == "tuya":
             return data  # raw base64 Tuya-format
+        # Each k=v pair must contain exactly one '='; split(...) returns a
+        # list of length 1 or >2 otherwise, which dict() then rejects with
+        # ValueError. We catch ValueError specifically (parse failure) so
+        # that genuine bugs in encoders surface with their original trace.
         data = dict(v.split("=") for v in data.split(","))
         data = {k: _coerce(v) for k, v in data.items()}
-    except Exception:
-        raise ValueError(f"Invalid command format: {s}")
+    except ValueError as exc:
+        raise ValueError(f"Invalid command format: {s}") from exc
     if fmt not in RC_CONVERTERS:
         raise ValueError(f"Unknown format: {fmt}")
     encoder, _ = RC_CONVERTERS[fmt]

--- a/tests/midea_analysis.py
+++ b/tests/midea_analysis.py
@@ -1,0 +1,174 @@
+"""
+Diagnostic helper for analyzing raw Midea AC samples.
+
+Run as:
+    python tests/midea_analysis.py
+
+It expects user-supplied samples in MIDEA_SAMPLES below. Decodes each one
+into 6 bytes (LSB-first wire convention), validates Midea invariants
+(B0=0xB2, B1=~B0, B3=~B2, B5=~B4, second half repeats first), and prints
+a side-by-side diff so you can see which bits differ between commands.
+
+Use this BEFORE writing the real decoder to confirm your AC speaks Midea
+and to figure out the field layout.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PULSE_PATH = ROOT / "custom_components" / "flipper_rc" / "pulse.py"
+spec = importlib.util.spec_from_file_location("pulse", PULSE_PATH)
+pulse = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pulse)
+
+
+# Real samples captured by Flipper IR learn from EAS Electric EADVA25NT2
+# (Midea-OEM split AC). Add more samples here as you collect them — at
+# minimum: ac_off, cool_22, cool_24, cool_26, ideally also heat_22 and
+# differing fan speeds, so we can identify which bits encode each field.
+MIDEA_SAMPLES = {
+    "Power off": (
+        "raw:4454,4327,593,1557,592,482,592,1557,592,1558,591,483,591,483,591,1558,591,484,590,484,601,1548,601,474,590,484,601,1549,600,1549,600,475,599,1550,599,475,567,1582,598,1551,598,1551,598,1551,598,477,597,1552,597,1552,597,1553,596,478,596,478,596,478,596,478,596,1553,596,478,596,478,596,1554,595,1553,596,1554,595,479,595,479,595,479,595,479,595,480,594,480,594,480,594,480,594,1555,594,1555,594,1555,594,1556,593,1556,593,5148,4450,4331,599,1550,599,475,599,1551,598,1551,598,476,598,476,598,1551,598,477,597,477,597,1552,597,478,565,509,597,1552,597,1553,596,478,565,1584,596,478,596,1553,596,1553,596,1553,596,1554,595,479,595,1554,595,1554,595,1555,594,480,594,481,593,481,593,481,572,1577,593,481,593,481,593,1556,593,1556,593,1556,593,482,592,482,592,482,592,482,592,482,592,483,591,482,592,483,591,1557,592,1558,591,1558,591,1558,601,1548,601"
+    ),
+}
+
+# Midea reference timings (matches Flipper's AC parser)
+LEAD_PULSE = 4500
+LEAD_GAP = 4500
+PULSE = 560
+GAP_0 = 560
+GAP_1 = 1690
+INTER_MSG_GAP = 5100  # observed ~5148
+
+
+def parse_raw(s):
+    assert s.startswith("raw:")
+    return [int(v) for v in s[4:].split(",")]
+
+
+def split_halves(values):
+    """
+    Midea is two 48-bit messages with ~5100µs gap between them. Locate the
+    inter-message gap in the middle of the pulse stream and split.
+    """
+    # Bit pulses: 1 leading pulse + 1 leading gap + 48 * (pulse+gap) + closing pulse = 99 elements per half.
+    # The 100th element is either the closing gap to the inter-msg gap (~5100)
+    # or it IS the inter-msg gap. Then the second half follows.
+    # Use the actual gap value: find position where a gap > 4000 appears (after element 50+).
+    if len(values) < 100:
+        raise ValueError(f"Too short for Midea: {len(values)} elements")
+
+    # Look for the inter-message gap candidate around position 99..103
+    for i in range(95, min(110, len(values))):
+        if values[i] > 3000 and values[i] < 6000 and values[i] != LEAD_GAP:
+            # Could be the inter-message gap. Split here.
+            return values[:i], values[i + 1 :]
+    # Fall back: assume position 99
+    return values[:99], values[100:]
+
+
+def decode_half(values):
+    """Decode 48 bits using the same engine as flipper_rc's `ac` parser."""
+    return pulse.distance_decode(
+        values, LEAD_PULSE, LEAD_GAP, PULSE, GAP_0, GAP_1, 48
+    )
+
+
+def byte_lsb_to_msb(b):
+    """Reverse bit order in a byte: LSB-first wire encoding -> MSB-first (Midea docs convention)."""
+    out = 0
+    for i in range(8):
+        if b & (1 << i):
+            out |= 1 << (7 - i)
+    return out
+
+
+def fmt_bits_msb(b):
+    """Render a byte as 8-bit MSB-first binary string."""
+    return f"{b:08b}"
+
+
+def analyze(name, raw_str):
+    print(f"\n{'=' * 70}")
+    print(f"Sample: {name}")
+    print(f"{'=' * 70}")
+    values = parse_raw(raw_str)
+    print(f"Total elements: {len(values)}")
+    print(f"Header: {values[0]}, {values[1]}  (expected ~{LEAD_PULSE}/{LEAD_GAP})")
+
+    h1, h2 = split_halves(values)
+    print(f"Half 1 length: {len(h1)} elements")
+    print(f"Half 2 length: {len(h2)} elements")
+
+    try:
+        bytes1 = decode_half(h1)
+    except ValueError as e:
+        print(f"!! Half 1 decode failed: {e}")
+        return None
+    try:
+        bytes2 = decode_half(h2)
+    except ValueError as e:
+        print(f"!! Half 2 decode failed: {e}")
+        bytes2 = None
+
+    print(f"\nWire-LSB bytes (as flipper_rc reads them):")
+    print(f"  Half 1: {[f'0x{b:02X}' for b in bytes1]}")
+    if bytes2 is not None:
+        print(f"  Half 2: {[f'0x{b:02X}' for b in bytes2]}")
+        match = bytes1 == bytes2
+        print(f"  Halves match: {match}")
+
+    # Convert to MSB-first to align with IRremoteESP8266 / Midea spec docs.
+    msb = [byte_lsb_to_msb(b) for b in bytes1]
+    print(f"\nMSB-first bytes (Midea spec convention):")
+    for i, b in enumerate(msb):
+        print(f"  B{i}: 0x{b:02X}  ({fmt_bits_msb(b)})")
+
+    # Validate Midea invariants
+    print(f"\nMidea invariants:")
+    print(f"  B0 == 0xB2 (Midea AC marker, MSB):  {msb[0] == 0xB2}  (got 0x{msb[0]:02X})")
+    print(f"  B1 == ~B0 (LSB):  {bytes1[0] == bytes1[1] ^ 0xFF}")
+    print(f"  B3 == ~B2 (LSB):  {bytes1[2] == bytes1[3] ^ 0xFF}")
+    print(f"  B5 == ~B4 (LSB):  {bytes1[4] == bytes1[5] ^ 0xFF}")
+
+    return msb
+
+
+def diff_samples(samples_decoded):
+    """Print which bits differ across samples — helps map fields."""
+    if len(samples_decoded) < 2:
+        return
+    print(f"\n{'=' * 70}")
+    print("Bit-level diff across samples")
+    print(f"{'=' * 70}")
+    names = list(samples_decoded.keys())
+    print(f"Comparing: {names}")
+    for byte_idx in range(6):
+        col = [samples_decoded[n][byte_idx] for n in names]
+        if len(set(col)) == 1:
+            print(f"  B{byte_idx}: identical (0x{col[0]:02X})")
+            continue
+        print(f"  B{byte_idx}: differs!")
+        for n, v in zip(names, col):
+            print(f"     {n:<20}  0x{v:02X}  {fmt_bits_msb(v)}")
+        # Highlight which bits change
+        diff_mask = 0
+        ref = col[0]
+        for v in col[1:]:
+            diff_mask |= ref ^ v
+        print(f"     diff mask:           0x{diff_mask:02X}  {fmt_bits_msb(diff_mask)}")
+
+
+def main():
+    decoded = {}
+    for name, raw in MIDEA_SAMPLES.items():
+        msb = analyze(name, raw)
+        if msb is not None:
+            decoded[name] = msb
+    diff_samples(decoded)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_midea.py
+++ b/tests/test_midea.py
@@ -207,6 +207,12 @@ def test_auto_encode_round_trip():
     # Auto mode (fan is forced, but accept any value for caller convenience)
     ("auto", 22, "auto", 0x1F, 0x78),
     ("auto", 24, "auto", 0x1F, 0x48),
+    # Heat 25 — temp Gray code 0xC, mode 0b11
+    ("heat", 25, "auto", 0xBF, 0xCC),
+    # Dry mode (fan locked to AC-controlled, like auto)
+    ("dry",  24, "auto", 0x1F, 0x44),
+    # Fan mode (temp ignored, sentinel 0xE)
+    ("fan",  None, "auto", 0xBF, 0xE4),
 ])
 def test_fields_to_bytes_matches_real_captures(mode, temp, fan, expected_a, expected_b):
     a, b = rc_encoder._midea_fields_to_bytes(mode=mode, temp=temp, fan=fan)
@@ -244,15 +250,31 @@ def test_fields_to_bytes_rejects_bad_input():
 def test_bytes_to_fields_round_trip_for_all_known_combos():
     """For every (mode, temp, fan) combo we know how to encode, the bytes
     decoded back must yield the same fields."""
-    for mode in ("cool", "heat", "auto"):
+    for mode in ("cool", "heat"):
         for temp in (17, 22, 24, 26, 30):
-            fans = ("auto",) if mode == "auto" else ("auto", "low", "med", "high")
-            for fan in fans:
+            for fan in ("auto", "low", "med", "high"):
                 a, b = rc_encoder._midea_fields_to_bytes(mode=mode, temp=temp, fan=fan)
                 fields = rc_encoder.midea_bytes_to_fields(a, b)
                 assert fields == {
                     "power": True, "mode": mode, "temp": temp, "fan": fan,
                 }, f"round-trip failed for ({mode}, {temp}, {fan}): got {fields}"
+
+    # Auto / dry: fan is locked to "auto" (AC decides)
+    for mode in ("auto", "dry"):
+        for temp in (17, 22, 24, 26, 30):
+            a, b = rc_encoder._midea_fields_to_bytes(mode=mode, temp=temp)
+            fields = rc_encoder.midea_bytes_to_fields(a, b)
+            assert fields == {
+                "power": True, "mode": mode, "temp": temp, "fan": "auto",
+            }, f"round-trip failed for ({mode}, {temp}): got {fields}"
+
+    # Fan mode: temp is omitted from the decoded output (sentinel 0xE).
+    for fan in ("auto", "low", "med", "high"):
+        a, b = rc_encoder._midea_fields_to_bytes(mode="fan", fan=fan)
+        fields = rc_encoder.midea_bytes_to_fields(a, b)
+        assert fields == {
+            "power": True, "mode": "fan", "fan": fan,
+        }, f"round-trip failed for fan/{fan}: got {fields}"
 
 
 def test_bytes_to_fields_recognizes_power_off():

--- a/tests/test_midea.py
+++ b/tests/test_midea.py
@@ -176,3 +176,141 @@ def test_auto_encode_round_trip():
     cmd_str = "midea:a=0x7B,b=0xE0"
     encoded = rc_encoder.rc_auto_encode(cmd_str)
     assert rc_encoder.rc_auto_decode(encoded) == cmd_str
+
+
+# === Field-level encoding ===
+#
+# Reference table — confirmed against real captures from EAS Electric
+# EADVA25NT2 (Midea OEM):
+#
+#   Power off                  → a=0x7B b=0xE0
+#   Auto 22°  fan=auto         → a=0x1F b=0x78
+#   Auto 24°  fan=auto         → a=0x1F b=0x48
+#   Cool 22°  fan=auto         → a=0xBF b=0x70
+#   Cool 22°  fan=low          → a=0x9F b=0x70
+#   Cool 22°  fan=med          → a=0x5F b=0x70
+#   Cool 22°  fan=high         → a=0x3F b=0x70
+#   Cool 26°  fan=auto         → a=0xBF b=0xD0
+#   Heat 22°  fan=auto         → a=0xBF b=0x7C
+
+
+@pytest.mark.parametrize("mode,temp,fan,expected_a,expected_b", [
+    # Cool mode, all fans, temp 22
+    ("cool", 22, "auto", 0xBF, 0x70),
+    ("cool", 22, "low",  0x9F, 0x70),
+    ("cool", 22, "med",  0x5F, 0x70),
+    ("cool", 22, "high", 0x3F, 0x70),
+    # Cool mode, temp variations
+    ("cool", 26, "auto", 0xBF, 0xD0),
+    # Heat mode
+    ("heat", 22, "auto", 0xBF, 0x7C),
+    # Auto mode (fan is forced, but accept any value for caller convenience)
+    ("auto", 22, "auto", 0x1F, 0x78),
+    ("auto", 24, "auto", 0x1F, 0x48),
+])
+def test_fields_to_bytes_matches_real_captures(mode, temp, fan, expected_a, expected_b):
+    a, b = rc_encoder._midea_fields_to_bytes(mode=mode, temp=temp, fan=fan)
+    assert (a, b) == (expected_a, expected_b), (
+        f"mode={mode}, temp={temp}, fan={fan} produced "
+        f"a=0x{a:02X}, b=0x{b:02X}, expected a=0x{expected_a:02X}, b=0x{expected_b:02X}"
+    )
+
+
+def test_fields_to_bytes_power_off_returns_magic_bytes():
+    a, b = rc_encoder._midea_fields_to_bytes(power="off")
+    assert (a, b) == (0x7B, 0xE0)
+    a, b = rc_encoder._midea_fields_to_bytes(power=False)
+    assert (a, b) == (0x7B, 0xE0)
+    # Power=off ignores other field params.
+    a, b = rc_encoder._midea_fields_to_bytes(mode="cool", temp=24, fan="high", power="off")
+    assert (a, b) == (0x7B, 0xE0)
+
+
+def test_fields_to_bytes_defaults():
+    """Defaults: mode=cool, temp=22, fan=auto, power=on."""
+    a, b = rc_encoder._midea_fields_to_bytes()
+    assert (a, b) == (0xBF, 0x70)
+
+
+def test_fields_to_bytes_rejects_bad_input():
+    with pytest.raises(ValueError, match="unsupported mode"):
+        rc_encoder._midea_fields_to_bytes(mode="freeze")
+    with pytest.raises(ValueError, match="unsupported fan"):
+        rc_encoder._midea_fields_to_bytes(mode="cool", fan="turbo")
+    with pytest.raises(ValueError, match="out of supported range"):
+        rc_encoder._midea_fields_to_bytes(mode="cool", temp=99)
+
+
+def test_bytes_to_fields_round_trip_for_all_known_combos():
+    """For every (mode, temp, fan) combo we know how to encode, the bytes
+    decoded back must yield the same fields."""
+    for mode in ("cool", "heat", "auto"):
+        for temp in (17, 22, 24, 26, 30):
+            fans = ("auto",) if mode == "auto" else ("auto", "low", "med", "high")
+            for fan in fans:
+                a, b = rc_encoder._midea_fields_to_bytes(mode=mode, temp=temp, fan=fan)
+                fields = rc_encoder.midea_bytes_to_fields(a, b)
+                assert fields == {
+                    "power": True, "mode": mode, "temp": temp, "fan": fan,
+                }, f"round-trip failed for ({mode}, {temp}, {fan}): got {fields}"
+
+
+def test_bytes_to_fields_recognizes_power_off():
+    assert rc_encoder.midea_bytes_to_fields(0x7B, 0xE0) == {"power": False}
+
+
+def test_midea_encode_field_form_matches_byte_form():
+    """midea:mode=cool,temp=22,fan=auto,power=on must produce bytes
+    identical to midea:a=0xBF,b=0x70."""
+    by_fields = rc_encoder.midea_encode(mode="cool", temp=22, fan="auto", power="on")
+    by_bytes = rc_encoder.midea_encode(a=0xBF, b=0x70)
+    assert by_fields == by_bytes
+
+
+def test_midea_encode_rejects_mixed_forms():
+    with pytest.raises(ValueError, match="not both"):
+        rc_encoder.midea_encode(a=0x12, b=0x34, mode="cool")
+
+
+def test_midea_encode_sleep_shorthand_matches_explicit_preamble():
+    """midea:mode=cool,sleep=on must equal midea:a=...,b=...,pa=0xE0,pb=0x03."""
+    by_sleep = rc_encoder.midea_encode(mode="cool", temp=22, fan="auto", sleep="on")
+    by_explicit = rc_encoder.midea_encode(a=0xBF, b=0x70, pa=0xE0, pb=0x03)
+    assert by_sleep == by_explicit
+
+
+def test_midea_encode_sleep_off_omits_preamble():
+    by_sleep_off = rc_encoder.midea_encode(mode="cool", temp=22, fan="auto", sleep="off")
+    by_no_sleep = rc_encoder.midea_encode(mode="cool", temp=22, fan="auto")
+    assert by_sleep_off == by_no_sleep
+
+
+def test_midea_encode_sleep_with_pa_raises():
+    with pytest.raises(ValueError, match="cannot use both"):
+        rc_encoder.midea_encode(a=0xBF, b=0x70, pa=0xE0, pb=0x03, sleep="on")
+
+
+@pytest.mark.parametrize("cmd_str,expected_ab", [
+    ("midea:mode=cool,temp=22,fan=auto", (0xBF, 0x70)),
+    ("midea:mode=cool,temp=26,fan=auto", (0xBF, 0xD0)),
+    ("midea:mode=heat,temp=22,fan=auto", (0xBF, 0x7C)),
+    ("midea:mode=auto,temp=24", (0x1F, 0x48)),
+    ("midea:power=off", (0x7B, 0xE0)),
+])
+def test_rc_auto_encode_field_form_round_trip(cmd_str, expected_ab):
+    """rc_auto_encode must accept field-level midea strings and produce
+    a signal that decodes to the matching a/b bytes."""
+    encoded = rc_encoder.rc_auto_encode(cmd_str)
+    decoded = rc_encoder.midea_decode(encoded)
+    a_str, b_str = decoded.split(",")[:2]
+    a = int(a_str.split("=")[1], 0)
+    b = int(b_str.split("=")[1], 0)
+    assert (a, b) == expected_ab
+
+
+def test_rc_auto_encode_sleep_string():
+    """rc_auto_encode must thread the `sleep=on` string through to midea_encode
+    and produce the 3-frame signal with the standard preamble."""
+    encoded = rc_encoder.rc_auto_encode("midea:mode=cool,temp=22,fan=auto,sleep=on")
+    decoded = rc_encoder.midea_decode(encoded)
+    assert decoded == "a=0xBF,b=0x70,pa=0xE0,pb=0x03"

--- a/tests/test_midea.py
+++ b/tests/test_midea.py
@@ -1,0 +1,161 @@
+"""Tests for the Midea AC protocol decoder/encoder."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG_DIR = ROOT / "custom_components" / "flipper_rc"
+
+# Load `pulse` and `manchester` as top-level modules first so `rc_encoder`
+# can `import pulse` / `import manchester` from its fallback path.
+for name in ("pulse", "manchester"):
+    spec = importlib.util.spec_from_file_location(name, PKG_DIR / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    sys.modules[name] = mod
+
+spec = importlib.util.spec_from_file_location("rc_encoder", PKG_DIR / "rc_encoder.py")
+rc_encoder = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rc_encoder)
+
+
+# Real captured sample from EAS Electric EADVA25NT2 (Midea-OEM split AC).
+# Command: "Power off" via the original IR remote.
+POWER_OFF_RAW = (
+    "4454,4327,593,1557,592,482,592,1557,592,1558,591,483,591,483,591,1558,591,484,"
+    "590,484,601,1548,601,474,590,484,601,1549,600,1549,600,475,599,1550,599,475,"
+    "567,1582,598,1551,598,1551,598,1551,598,477,597,1552,597,1552,597,1553,596,478,"
+    "596,478,596,478,596,478,596,1553,596,478,596,478,596,1554,595,1553,596,1554,"
+    "595,479,595,479,595,479,595,479,595,480,594,480,594,480,594,480,594,1555,594,"
+    "1555,594,1555,594,1556,593,1556,593,5148,4450,4331,599,1550,599,475,599,1551,"
+    "598,1551,598,476,598,476,598,1551,598,477,597,477,597,1552,597,478,565,509,"
+    "597,1552,597,1553,596,478,565,1584,596,478,596,1553,596,1553,596,1553,596,1554,"
+    "595,479,595,1554,595,1554,595,1555,594,480,594,481,593,481,593,481,572,1577,"
+    "593,481,593,481,593,1556,593,1556,593,1556,593,482,592,482,592,482,592,482,"
+    "592,482,592,483,591,482,592,483,591,1557,592,1558,591,1558,591,1558,601,1548,601"
+)
+
+
+def parse_raw(s):
+    return [int(v) for v in s.split(",")]
+
+
+def test_decode_real_power_off_sample():
+    values = parse_raw(POWER_OFF_RAW)
+    decoded = rc_encoder.midea_decode(values)
+    # Expected payload bytes in MSB-first reading: 0x7B, 0xE0
+    # (vendor 0xB2, 0x4D and inverses 0x84, 0x1F are validated by midea_decode itself)
+    assert decoded == "a=0x7B,b=0xE0"
+
+
+def test_decode_rejects_non_midea_vendor():
+    """A pure Gorenje/MDV packet (no 0xB2 vendor byte) must NOT decode as Midea."""
+    # Hand-crafted: vendor byte = 0xA1 (something else), valid inverse pairs
+    bytes_msb = [0xA1, 0xA1 ^ 0xFF, 0x12, 0x12 ^ 0xFF, 0x34, 0x34 ^ 0xFF]
+    raw = rc_encoder.pulse.distance_encode(
+        bytes_msb,
+        rc_encoder.MIDEA_LEADING_PULSE, rc_encoder.MIDEA_LEADING_GAP,
+        rc_encoder.MIDEA_PULSE, rc_encoder.MIDEA_GAP_0, rc_encoder.MIDEA_GAP_1,
+        48, msb_first=True,
+    )
+    raw = raw + [rc_encoder.MIDEA_INTER_GAP] + raw
+    with pytest.raises(ValueError, match="vendor byte expected 0xB2"):
+        rc_encoder.midea_decode(raw)
+
+
+def test_decode_rejects_broken_inverse_pair():
+    """Tamper with B3 so the inverse-pair invariant fails."""
+    bytes_msb = [0xB2, 0x4D, 0x12, 0x99, 0x34, 0x34 ^ 0xFF]  # B3 != ~B2
+    raw = rc_encoder.pulse.distance_encode(
+        bytes_msb,
+        rc_encoder.MIDEA_LEADING_PULSE, rc_encoder.MIDEA_LEADING_GAP,
+        rc_encoder.MIDEA_PULSE, rc_encoder.MIDEA_GAP_0, rc_encoder.MIDEA_GAP_1,
+        48, msb_first=True,
+    )
+    raw = raw + [rc_encoder.MIDEA_INTER_GAP] + raw
+    with pytest.raises(ValueError, match="invalid inverse pair"):
+        rc_encoder.midea_decode(raw)
+
+
+def test_decode_rejects_mismatched_halves():
+    """If the two repeated 48-bit packets differ, decode must fail."""
+    bytes1 = [0xB2, 0x4D, 0x12, 0x12 ^ 0xFF, 0x34, 0x34 ^ 0xFF]
+    bytes2 = [0xB2, 0x4D, 0x99, 0x99 ^ 0xFF, 0x34, 0x34 ^ 0xFF]  # different B2
+    half1 = rc_encoder.pulse.distance_encode(
+        bytes1,
+        rc_encoder.MIDEA_LEADING_PULSE, rc_encoder.MIDEA_LEADING_GAP,
+        rc_encoder.MIDEA_PULSE, rc_encoder.MIDEA_GAP_0, rc_encoder.MIDEA_GAP_1,
+        48, msb_first=True,
+    )
+    half2 = rc_encoder.pulse.distance_encode(
+        bytes2,
+        rc_encoder.MIDEA_LEADING_PULSE, rc_encoder.MIDEA_LEADING_GAP,
+        rc_encoder.MIDEA_PULSE, rc_encoder.MIDEA_GAP_0, rc_encoder.MIDEA_GAP_1,
+        48, msb_first=True,
+    )
+    raw = half1 + [rc_encoder.MIDEA_INTER_GAP] + half2
+    with pytest.raises(ValueError, match="repeated halves differ"):
+        rc_encoder.midea_decode(raw)
+
+
+def test_encode_round_trip_zero_payload():
+    encoded = rc_encoder.midea_encode(a=0x00, b=0x00)
+    decoded = rc_encoder.midea_decode(encoded)
+    assert decoded == "a=0x00,b=0x00"
+
+
+def test_encode_round_trip_arbitrary_payload():
+    encoded = rc_encoder.midea_encode(a=0xA5, b=0x5A)
+    decoded = rc_encoder.midea_decode(encoded)
+    assert decoded == "a=0xA5,b=0x5A"
+
+
+def test_encode_round_trip_power_off_payload():
+    """Encoding the real Power off payload should produce a packet that
+    decodes back to the same bytes."""
+    encoded = rc_encoder.midea_encode(a=0x7B, b=0xE0)
+    decoded = rc_encoder.midea_decode(encoded)
+    assert decoded == "a=0x7B,b=0xE0"
+    # And the encoded length matches the real captured signal (199 elements).
+    assert len(encoded) == 199
+
+
+def test_encode_rejects_out_of_range():
+    with pytest.raises(ValueError, match="'a' must be in range"):
+        rc_encoder.midea_encode(a=0x100, b=0)
+    with pytest.raises(ValueError, match="'b' must be in range"):
+        rc_encoder.midea_encode(a=0, b=-1)
+
+
+def test_auto_decode_picks_midea_for_real_sample():
+    """rc_auto_decode should pick midea (not ac) for a 0xB2-vendor packet."""
+    values = parse_raw(POWER_OFF_RAW)
+    decoded = rc_encoder.rc_auto_decode(values)
+    assert decoded.startswith("midea:")
+    assert decoded == "midea:a=0x7B,b=0xE0"
+
+
+def test_auto_decode_falls_back_to_ac_for_non_midea_vendor():
+    """For Gorenje/MDV-style packets (vendor != 0xB2), midea must be skipped
+    and `ac` should still pick them up."""
+    # Build a Gorenje-like packet: 6 bytes, inverse pairs, vendor = 0x4C (any non-0xB2).
+    addr = 0x4C
+    cmd = 0x1234
+    encoded = rc_encoder.air_conditioner_encode(addr=addr, cmd=cmd, double=1)
+    decoded = rc_encoder.rc_auto_decode(encoded)
+    assert decoded.startswith("ac:")
+    # The ac decoder reports addr/cmd in its own format
+    assert "addr=0x4C" in decoded
+    assert "cmd=0x1234" in decoded
+
+
+def test_auto_encode_round_trip():
+    """rc_auto_encode("midea:a=0xXX,b=0xYY") must produce a signal that
+    rc_auto_decode reads back as the same midea string."""
+    cmd_str = "midea:a=0x7B,b=0xE0"
+    encoded = rc_encoder.rc_auto_encode(cmd_str)
+    assert rc_encoder.rc_auto_decode(encoded) == cmd_str

--- a/tests/test_midea.py
+++ b/tests/test_midea.py
@@ -81,25 +81,42 @@ def test_decode_rejects_broken_inverse_pair():
         rc_encoder.midea_decode(raw)
 
 
-def test_decode_rejects_mismatched_halves():
-    """If the two repeated 48-bit packets differ, decode must fail."""
-    bytes1 = [0xB2, 0x4D, 0x12, 0x12 ^ 0xFF, 0x34, 0x34 ^ 0xFF]
-    bytes2 = [0xB2, 0x4D, 0x99, 0x99 ^ 0xFF, 0x34, 0x34 ^ 0xFF]  # different B2
-    half1 = rc_encoder.pulse.distance_encode(
-        bytes1,
-        rc_encoder.MIDEA_LEADING_PULSE, rc_encoder.MIDEA_LEADING_GAP,
-        rc_encoder.MIDEA_PULSE, rc_encoder.MIDEA_GAP_0, rc_encoder.MIDEA_GAP_1,
-        48, msb_first=True,
+def test_decode_two_frame_signal_extracts_command_and_preamble():
+    """A 3-packet signal (preamble + command + command) decodes both bytes
+    of the actual command and exposes the preamble as `pa`/`pb`."""
+    preamble = rc_encoder._midea_pack(0xE0, 0x03)
+    command = rc_encoder._midea_pack(0xBF, 0xD0)
+    raw = (
+        preamble + [rc_encoder.MIDEA_INTER_GAP]
+        + command + [rc_encoder.MIDEA_INTER_GAP]
+        + command
     )
-    half2 = rc_encoder.pulse.distance_encode(
-        bytes2,
-        rc_encoder.MIDEA_LEADING_PULSE, rc_encoder.MIDEA_LEADING_GAP,
-        rc_encoder.MIDEA_PULSE, rc_encoder.MIDEA_GAP_0, rc_encoder.MIDEA_GAP_1,
-        48, msb_first=True,
+    decoded = rc_encoder.midea_decode(raw)
+    assert decoded == "a=0xBF,b=0xD0,pa=0xE0,pb=0x03"
+
+
+def test_decode_three_identical_frames_returns_simple_form():
+    """If all 3 packets are identical (no preamble), no `pa`/`pb` annotation."""
+    packet = rc_encoder._midea_pack(0xAA, 0x55)
+    raw = (
+        packet + [rc_encoder.MIDEA_INTER_GAP]
+        + packet + [rc_encoder.MIDEA_INTER_GAP]
+        + packet
     )
-    raw = half1 + [rc_encoder.MIDEA_INTER_GAP] + half2
-    with pytest.raises(ValueError, match="repeated halves differ"):
-        rc_encoder.midea_decode(raw)
+    assert rc_encoder.midea_decode(raw) == "a=0xAA,b=0x55"
+
+
+def test_encode_round_trip_with_preamble():
+    encoded = rc_encoder.midea_encode(a=0xBF, b=0xD0, pa=0xE0, pb=0x03)
+    assert len(encoded) == 99 * 3 + 2  # 3 packets, 2 inter-packet gaps
+    assert rc_encoder.midea_decode(encoded) == "a=0xBF,b=0xD0,pa=0xE0,pb=0x03"
+
+
+def test_encode_rejects_partial_preamble():
+    with pytest.raises(ValueError, match="must be provided together"):
+        rc_encoder.midea_encode(a=0x12, b=0x34, pa=0x56)
+    with pytest.raises(ValueError, match="must be provided together"):
+        rc_encoder.midea_encode(a=0x12, b=0x34, pb=0x78)
 
 
 def test_encode_round_trip_zero_payload():

--- a/tests/test_midea.py
+++ b/tests/test_midea.py
@@ -290,7 +290,7 @@ def test_midea_encode_field_form_matches_byte_form():
 
 
 def test_midea_encode_rejects_mixed_forms():
-    with pytest.raises(ValueError, match="not both"):
+    with pytest.raises(ValueError, match="only one of"):
         rc_encoder.midea_encode(a=0x12, b=0x34, mode="cool")
 
 
@@ -336,3 +336,100 @@ def test_rc_auto_encode_sleep_string():
     encoded = rc_encoder.rc_auto_encode("midea:mode=cool,temp=22,fan=auto,sleep=on")
     decoded = rc_encoder.midea_decode(encoded)
     assert decoded == "a=0xBF,b=0x70,pa=0xE0,pb=0x03"
+
+
+# === Special toggle buttons (swing / turbo / LED) ===
+#
+# Reference values captured from EAS Electric EADVA25NT2 remote:
+#   swing toggle: vendor 0xB2 (regular state vendor), bytes a=0x6B, b=0xE0
+#   turbo:        vendor 0xB5 (special),              bytes a=0xF5, b=0xA2
+#   led:          vendor 0xB5 (special),              bytes a=0xF5, b=0xA5
+
+
+@pytest.mark.parametrize("button,vendor,a,b", [
+    ("swing", 0xB2, 0x6B, 0xE0),
+    ("turbo", 0xB5, 0xF5, 0xA2),
+    ("led",   0xB5, 0xF5, 0xA5),
+])
+def test_button_encode_round_trip(button, vendor, a, b):
+    """Each named button encodes to a 199-element signal whose payload
+    matches the captured reference values."""
+    encoded = rc_encoder.midea_encode(button=button)
+    assert len(encoded) == 199  # single 48-bit packet repeated twice
+    decoded = rc_encoder.midea_decode(encoded)
+    assert decoded == f"button={button}"
+
+
+def test_button_encode_rejects_unknown():
+    with pytest.raises(ValueError, match="unknown button"):
+        rc_encoder.midea_encode(button="boost")
+
+
+def test_button_encode_rejects_combination_with_state_params():
+    with pytest.raises(ValueError, match="only one of"):
+        rc_encoder.midea_encode(button="turbo", mode="cool")
+    with pytest.raises(ValueError, match="only one of"):
+        rc_encoder.midea_encode(button="turbo", a=0x12, b=0x34)
+
+
+def test_button_encode_rejects_pa_pb_sleep():
+    with pytest.raises(ValueError, match="do not support pa/pb/sleep"):
+        rc_encoder.midea_encode(button="turbo", sleep="on")
+    with pytest.raises(ValueError, match="do not support pa/pb/sleep"):
+        rc_encoder.midea_encode(button="led", pa=0x12, pb=0x34)
+
+
+def test_decode_special_vendor_known_button():
+    """A 0xB5-vendor packet whose bytes match a known button decodes as
+    `button=name`."""
+    raw = rc_encoder._midea_pack(0xF5, 0xA2, vendor=0xB5)
+    raw = raw + [rc_encoder.MIDEA_INTER_GAP] + raw
+    assert rc_encoder.midea_decode(raw) == "button=turbo"
+
+
+def test_decode_special_vendor_unknown_button():
+    """A 0xB5-vendor packet whose bytes don't match any known button
+    falls back to `button=unknown,a=...,b=...`."""
+    raw = rc_encoder._midea_pack(0x11, 0x22, vendor=0xB5)
+    raw = raw + [rc_encoder.MIDEA_INTER_GAP] + raw
+    assert rc_encoder.midea_decode(raw) == "button=unknown,a=0x11,b=0x22"
+
+
+def test_rc_auto_encode_button_string():
+    """rc_auto_encode threads `button=turbo` to midea_encode and the
+    signal round-trips."""
+    encoded = rc_encoder.rc_auto_encode("midea:button=turbo")
+    decoded = rc_encoder.rc_auto_decode(encoded)
+    assert decoded == "midea:button=turbo"
+
+
+def test_rc_auto_encode_button_swing_uses_state_vendor():
+    """Swing toggle uses the regular state-command vendor (0xB2), so its
+    encoded bytes must match the byte-level form `a=0x6B,b=0xE0`."""
+    by_button = rc_encoder.rc_auto_encode("midea:button=swing")
+    by_bytes = rc_encoder.rc_auto_encode("midea:a=0x6B,b=0xE0")
+    assert by_button == by_bytes
+
+
+def test_real_turbo_capture_decodes_as_button():
+    """The real raw signal captured for the Turbo button on the EAS
+    Electric remote must now decode as `button=turbo` (previously it
+    decoded as `ac:addr=0xAD,cmd=0x45AF` which round-tripped to a
+    different — non-functional — packet)."""
+    raw = (
+        "4453,4330,569,1581,568,506,600,1550,567,1581,568,507,599,1551,566,508,"
+        "598,1552,565,509,597,1552,597,478,596,478,596,1553,564,510,596,1553,"
+        "596,478,596,1553,596,1553,596,1554,595,1554,595,480,594,1554,595,480,"
+        "594,1555,594,481,593,481,593,481,593,481,593,1556,593,482,592,1557,"
+        "592,482,592,1557,602,472,602,1547,602,473,601,473,601,473,601,1548,"
+        "601,473,601,473,601,1548,601,474,600,1549,600,1550,599,1550,599,476,"
+        "598,1551,598,5143,4454,4327,593,1557,592,483,591,1558,601,1547,602,"
+        "473,601,1548,601,473,601,1549,600,474,600,1549,600,475,599,475,599,"
+        "1550,599,476,598,1551,598,477,597,1552,597,1552,597,1553,596,1553,"
+        "596,479,595,1553,596,479,595,1554,595,479,595,480,594,480,594,480,"
+        "594,1555,594,480,594,1555,594,481,593,1556,593,481,593,1557,592,482,"
+        "592,482,592,482,592,1557,602,472,602,473,601,1548,601,473,601,1548,"
+        "601,1548,601,1549,600,475,599,1550,599"
+    )
+    values = [int(v) for v in raw.split(",")]
+    assert rc_encoder.midea_decode(values) == "button=turbo"


### PR DESCRIPTION
Hi!

## Summary

Adds support for the Midea-family 48-bit AC protocol used by many OEM rebranders (Pioneer System, Comfee, Kaysun, Trotec, Lennox, EAS Electric, MDV, and various no-name Chinese splits).

These remotes use a wire structure superficially similar to the existing `ac` parser (Gorenje/MDV variant) — 48 bits, byte-pair inverses, ~4500/4500 header — so they were auto-decoded as `ac:`. But the produced codes did not survive a re-encode round-trip:

- The `ac` decoder needs `≥200` raw elements to recognise the doubled signal; real Midea remotes emit 199 (no closing gap before the second packet), so `double=1` was never set on decode.
- The `ac` encoder uses a `560µs` inter-packet gap, while Midea remotes use `~5100µs`. Re-encoded packets had the two halves merged into a single garbled signal, which real ACs ignored.

The new `midea` protocol handles three flavours of Midea-OEM codes:

### State commands (vendor `0xB2`)

  - **Byte-level:**
    - `midea:a=0x7B,b=0xE0` — fixed power-off magic value.
    - `midea:a=0xBF,b=0x70` — Cool 22°C, fan auto.
    - `midea:a=0xBF,b=0x70,pa=0xE0,pb=0x03` — same with the standard sleep preamble.
  - **Field-level:**
    - `midea:mode=cool,temp=22,fan=auto`
    - `midea:mode=heat,temp=25` (fan defaults to `auto`)
    - `midea:mode=auto,temp=24` / `midea:mode=dry,temp=24` (fan locked, AC chooses)
    - `midea:mode=fan,fan=high` (no temp; sentinel 0xE on the wire)
    - `midea:power=off`
    - `midea:mode=cool,temp=22,sleep=on` (sleep shorthand prepends the preamble)

### Toggle/special commands (vendor `0xB5`, plus one mapped to `0xB2`)

  - `midea:button=swing` — toggle vertical swing (uses `0xB2`)
  - `midea:button=turbo` — 10-minute boost cool/heat
  - `midea:button=led` — toggle indoor display + beep

### Field map (verified against 15 real captures from EAS Electric EADVA25NT2)

State command bytes (MSB on the wire):

| Bit slot | Field |
|---|---|
| `b[7..4]` | 4-bit Gray-coded temperature, identical to the IRremoteESP8266 reference table |
| `b[3..2]` | mode: `cool`=00, `auto`=10, `heat`=11, `dry`=01 (with `a[7..5]`=0), `fan`=01 (with `a[7..5]`≠0) |
| `b[1..0]` | always 0 |
| `a[7..5]` | fan: `auto`=101, `low`=100, `med`=010, `high`=001; `auto`/`dry` modes force 000 |
| `a[4,3,1,0]` | always 1 |
| `a[2]` | power |

Multi-frame structure: pressing the Sleep button (or, on some captures, mode-change) prepends a `(0xE0, 0x03)` preamble frame before the state frame, repeated twice — yielding a 299-element raw signal. Without the preamble, the AC ignores the payload. The `pa`/`pb` parameters and the `sleep=on` shorthand cover this.

### Implementation notes

- `midea` is registered before `ac` in `RC_CONVERTERS`, so vendor-`0xB2` and vendor-`0xB5` packets are claimed by the new parser; non-Midea AC packets fall through to `ac` as before.
- `_midea_pack` is parameterised by vendor so the same encoding pipeline serves both state and special commands.
- To make string parameters work in `rc_auto_encode` (e.g., `mode=cool`), value coercion now falls back to the raw string instead of raising. This is backward-compatible: every existing protocol passes numeric values that parse fine via `int(v, 0)`.
- `dry` and `fan` modes share `mode_bits=0b01` on the wire; the parser disambiguates via `fan_bits` (dry locks the fan to 000, fan-mode allows user values).

## Test plan

- [x] All existing tests pass — 22 total before, 63 total after.
- [x] Round-trip encode/decode for every supported parameter form.
- [x] All 15 real captured samples (Power off, Auto 22/24, Cool 22 ×4 fans, Cool 26, Heat 22 auto, Heat 25 auto, Dry 24, Fan 24, Sleep, Swing, Turbo, LED) decode to expected fields/buttons.
- [x] Preamble (3-frame) capture decoded and re-encoded faithfully (199 vs 299 element signals).
- [x] Non-Midea AC packets (vendor != 0xB2/0xB5) still decode as `ac:` — verified by `test_auto_decode_falls_back_to_ac_for_non_midea_vendor`.
- [x] Verified on real hardware via Home Assistant: `midea:mode=cool,temp=22,fan=auto`, `midea:button=turbo`, etc. all work as expected on an EAS Electric EADVA25NT2 split AC via Flipper Zero.

## Notes / future work

- Tested only on EAS Electric EADVA25NT2. The bit layout is consistent with what's documented for Midea broadly (Pioneer System, Comfee, Kaysun, Trotec, Lennox, MDV, and many Chinese splits use the same wire format), but other OEMs may have different magic constants for special buttons. Adding more brand-specific buttons is straightforward — extend the `MIDEA_BUTTONS` dict.
- Some Midea remotes use the "second-half-inverted" variant from IRremoteESP8266; that variant is NOT covered here. If demand emerges, a `midea-inv` variant can be added.
- The 4-bit Gray temperature table covers 17–30°C, matching what the protocol allows. Fahrenheit captures haven't been collected.